### PR TITLE
Move off Buildjet Runner for ARM Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ global-artifacts-jobs = ["./build-linux-pkgs"]
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Publish jobs to run in CI
-pr-run-mode = "plan"
+pr-run-mode = "upload"
 # Whether to publish prereleases to package managers
 publish-prereleases = true
 # Post-announce jobs to run in CI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,6 @@ publish-prereleases = true
 # Post-announce jobs to run in CI
 post-announce-jobs = ["./dotslash"]
 
-[workspace.metadata.dist.github-custom-runners]
-aarch64-unknown-linux-gnu = "buildjet-8vcpu-ubuntu-2204-arm"
-aarch64-unknown-linux-musl = "buildjet-8vcpu-ubuntu-2204-arm"
-
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"


### PR DESCRIPTION
Moving to new org breaks Builderjet. Make the build happen on GitHub infra only.