### PR TITLE
Recurse through subdirectories when loading configs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,6 +527,7 @@ dependencies = [
  "escargot",
  "glob",
  "human-panic",
+ "ignore",
  "inquire",
  "itertools",
  "json",
@@ -554,7 +555,6 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "vergen",
- "walkdir",
  "which",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,6 +554,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "vergen",
+ "walkdir",
  "which",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,4 +73,4 @@ derive_builder = "0.20"
 strum = { version = "0.26", features = ["derive"] }
 jsonschema = "0.17"
 tracing = "0.1.40"
-walkdir = "2.5.0"
+ignore = "0.4.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,4 @@ derive_builder = "0.20"
 strum = { version = "0.26", features = ["derive"] }
 jsonschema = "0.17"
 tracing = "0.1.40"
+walkdir = "2.5.0"

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -34,6 +34,8 @@ Unlike Kubernetes, the `name` field can be any string, without any DNS related c
 
 Additionally, scope will look for shared config in the directory `../etc/scope` relative to where the executable is located.
 
+To exclude files from being loaded, put a [gitignore style](https://git-scm.com/docs/gitignore) file named `.ignore` into a config directory.
+
 ## CLI Options
 All commands support the following options
 

--- a/examples/.scope/shared/disk-full.yaml
+++ b/examples/.scope/shared/disk-full.yaml
@@ -1,0 +1,8 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeKnownError
+metadata:
+  name: disk-full
+  description: The disk is full of files
+spec:
+  pattern: because the disk is full
+  help: Delete some unused files, and empty the trash.

--- a/scope/Cargo.toml
+++ b/scope/Cargo.toml
@@ -64,7 +64,7 @@ derive_builder.workspace = true
 strum.workspace = true
 jsonschema.workspace = true
 tracing.workspace = true
-walkdir.workspace = true
+ignore.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/scope/Cargo.toml
+++ b/scope/Cargo.toml
@@ -64,6 +64,7 @@ derive_builder.workspace = true
 strum.workspace = true
 jsonschema.workspace = true
 tracing.workspace = true
+walkdir.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/scope/src/shared/config_load.rs
+++ b/scope/src/shared/config_load.rs
@@ -8,10 +8,10 @@ use anyhow::{anyhow, Result};
 use clap::{ArgGroup, Parser};
 use colored::*;
 use directories::{BaseDirs, UserDirs};
+use ignore::Walk;
 use itertools::Itertools;
 use serde::Deserialize;
 use serde_yaml::{Deserializer, Value};
-use ignore::Walk;
 
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
@@ -317,7 +317,7 @@ fn expand_path(path: &Path) -> Result<Vec<PathBuf>> {
 
     if path.is_dir() {
         let mut files = Vec::new();
-        for dir_entry in Walk::new(path).into_iter().filter_map(|e| e.ok()) {
+        for dir_entry in Walk::new(path).filter_map(|e| e.ok()) {
             if !dir_entry.path().is_file() {
                 continue;
             }

--- a/scope/src/shared/config_load.rs
+++ b/scope/src/shared/config_load.rs
@@ -11,7 +11,7 @@ use directories::{BaseDirs, UserDirs};
 use itertools::Itertools;
 use serde::Deserialize;
 use serde_yaml::{Deserializer, Value};
-use walkdir::WalkDir;
+use ignore::Walk;
 
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
@@ -317,7 +317,7 @@ fn expand_path(path: &Path) -> Result<Vec<PathBuf>> {
 
     if path.is_dir() {
         let mut files = Vec::new();
-        for dir_entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
+        for dir_entry in Walk::new(path).into_iter().filter_map(|e| e.ok()) {
             if !dir_entry.path().is_file() {
                 continue;
             }

--- a/scope/src/shared/config_load.rs
+++ b/scope/src/shared/config_load.rs
@@ -11,6 +11,7 @@ use directories::{BaseDirs, UserDirs};
 use itertools::Itertools;
 use serde::Deserialize;
 use serde_yaml::{Deserializer, Value};
+use walkdir::WalkDir;
 
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
@@ -316,12 +317,12 @@ fn expand_path(path: &Path) -> Result<Vec<PathBuf>> {
 
     if path.is_dir() {
         let mut files = Vec::new();
-        for dir_entry in fs::read_dir(path)?.flatten() {
+        for dir_entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
             if !dir_entry.path().is_file() {
                 continue;
             }
 
-            let file_path = dir_entry.path();
+            let file_path = dir_entry.path().to_path_buf();
             let extension = file_path.extension();
             if extension == Some(OsStr::new("yaml")) || extension == Some(OsStr::new("yml")) {
                 debug!(target: "user", "Found file {:?}", file_path);

--- a/scope/tests/integration_tests.rs
+++ b/scope/tests/integration_tests.rs
@@ -26,6 +26,7 @@ fn test_list_reports_all_config() {
         .success()
         .stdout(predicate::str::contains("ScopeDoctorCheck/path-exists"))
         .stdout(predicate::str::contains("ScopeKnownError/error-exists"))
+        .stdout(predicate::str::contains("ScopeKnownError/disk-full"))
         .stdout(predicate::str::contains("ScopeDoctorGroup/group-1"))
         .stdout(predicate::str::contains("ScopeReportDefinition/template"))
         .stdout(predicate::str::contains("ScopeReportLocation/github"))


### PR DESCRIPTION
Previously, Scope would only load YAML config files from the root of each config directory. This limited the ability to group configs into folders.

This PR changes Scope to walk each config directory looking for files.