### PR TITLE
Add support to only a fix, but no check

### DIFF
--- a/examples/.scope/doctor-group-1.yaml
+++ b/examples/.scope/doctor-group-1.yaml
@@ -6,13 +6,21 @@ metadata:
 spec:
   actions:
     - description: foo1
+      name: fail then pass
       check:
         commands:
           - ./scripts/fail-first-call foo
       fix:
         commands:
           - ../bin/pip-install.sh
+    - description: sleep
+      name: "sleep"
+      check: { }
+      fix:
+        commands:
+          - sleep 1
     - description: foo2
+      name: paths
       check:
         paths:
           - '**/requirements.txt'

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -88,6 +88,9 @@ where
                     ActionRunResult::CheckSucceeded => {
                         info!(target: "user", group = group_name, name = action.name(), "Check was successful");
                     }
+                    ActionRunResult::NoCheckFixSucceeded => {
+                        info!(target: "user", group = group_name, name = action.name(), "Check ran successfully");
+                    }
                     ActionRunResult::CheckFailedFixSucceedVerifySucceed => {
                         info!(target: "user", group = group_name, name = action.name(), "Check initially failed, fix was successful");
                     }

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -89,7 +89,7 @@ where
                         info!(target: "user", group = group_name, name = action.name(), "Check was successful");
                     }
                     ActionRunResult::NoCheckFixSucceeded => {
-                        info!(target: "user", group = group_name, name = action.name(), "Check ran successfully");
+                        info!(target: "user", group = group_name, name = action.name(), "Fix ran successfully");
                     }
                     ActionRunResult::CheckFailedFixSucceedVerifySucceed => {
                         info!(target: "user", group = group_name, name = action.name(), "Check initially failed, fix was successful");
@@ -122,6 +122,7 @@ where
 
                 match action_result {
                     ActionRunResult::CheckSucceeded
+                    | ActionRunResult::NoCheckFixSucceeded
                     | ActionRunResult::CheckFailedFixSucceedVerifySucceed => {}
                     ActionRunResult::CheckFailedFixFailedStop => {
                         skip_remaining = true;

--- a/scope/tests/integration_tests.rs
+++ b/scope/tests/integration_tests.rs
@@ -208,10 +208,11 @@ fn test_run_group_1() {
     result
         .failure()
         .stdout(predicate::str::contains(
-            "Check initially failed, fix was successful, group: \"group-1\", name: \"1\"",
+            "Check initially failed, fix was successful, group: \"group-1\", name: \"fail then pass\"",
         ))
+        .stdout(predicate::str::contains("Fix ran successfully, group: \"group-1\", name: \"sleep\""))
         .stdout(predicate::str::contains(
-            "Check failed, no fix provided, group: \"group-1\", name: \"2\"",
+            "Check failed, no fix provided, group: \"group-1\", name: \"paths\"",
         ))
         .stdout(predicate::str::contains("Failed to write updated cache to disk").not());
 }


### PR DESCRIPTION
This will ensure that if you only have a fix, it will always run, and if the result succeeds, then the run will also succeed.

Before this change, the group would fail because the check cache would show "needs work".

This also fixes a logic issue where the task shouldn't succeed without running all checks.