### PR TITLE
Remove linux arm64 targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ installers = ["shell", "homebrew"]
 # A GitHub repo to push Homebrew formulas to
 tap = "oscope-dev/homebrew-formulas"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
 # Global artifacts jobs to run in CI
 global-artifacts-jobs = ["./build-linux-pkgs"]
 # Publish jobs to run in CI

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.75.0"
 components = ["clippy", "rustfmt"]
-targets = ["x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
+targets = ["x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]


### PR DESCRIPTION
## Problem
Release builds are failing because of an [inability to get linux aarch64 runners](https://github.com/oscope-dev/scope/actions/runs/8379362926/job/22946109451).

## Solution
Remove `aarch64-unknown-linux-gnu` as a target.