### PR TITLE
Use cross to build aarch64-linux artifact

### DIFF
--- a/.github/bin/build-with-cross.sh
+++ b/.github/bin/build-with-cross.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -eux
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# install cross if it doesn't exist
+if ! command -v cross &> /dev/null; then
+    cargo install cross
+fi
+
+cross build --release --target $1
+
+ARTIFACT_DIR="$DIR/../../target/dev-scope-$1"
+rm -rf $ARTIFACT_DIR || true
+mkdir $ARTIFACT_DIR
+cp $DIR/../../LICENSE $ARTIFACT_DIR
+cp $DIR/../../README.md $ARTIFACT_DIR
+cp $DIR/../../scope/CHANGELOG.md $ARTIFACT_DIR
+cp $DIR/../../target/$1/release/scope $ARTIFACT_DIR
+cp $DIR/../../target/$1/release/scope-intercept $ARTIFACT_DIR
+
+pushd $DIR/../../target
+rm dev-scope-$1.tar.xz || true
+tar cfJ dev-scope-$1.tar.xz dev-scope-$1
+

--- a/.github/workflows/build-linux-arm.yml
+++ b/.github/workflows/build-linux-arm.yml
@@ -1,0 +1,29 @@
+name: Continuous integration
+on:
+  # Defining workflow_call means that this workflow can be called from
+  # your main workflow job
+  workflow_call:
+    # cargo-dist exposes the plan from the plan step, as a JSON string,
+    # to your job if it needs it
+    inputs:
+      plan:
+        required: true
+        type: string
+
+jobs:
+  linux-arm:
+    name: Build Linux ARM Artifact
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update
+      - uses: Swatinem/rust-cache@v2
+      - name: cargo build
+        run: .github/bin/build-with-cross.sh aarch64-unknown-linux-gnu
+      - name: Upload ARM Linux
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-build-local-aarch64-unknown-linux-gnu
+          path: |
+            target/dev-scope-aarch64-unknown-linux-gnu.tar.xz
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,11 +147,11 @@ jobs:
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
 
-  custom-linux-arm:
+  custom-build-linux-arm:
     needs:
       - plan
     if: ${{ needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload' }}
-    uses: ./.github/workflows/linux-arm.yml
+    uses: ./.github/workflows/build-linux-arm.yml
     with:
       plan: ${{ needs.plan.outputs.val }}
     secrets: inherit
@@ -161,7 +161,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-      - custom-linux-arm
+      - custom-build-linux-arm
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -204,7 +204,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-      - custom-linux-arm
+      - custom-build-linux-arm
     uses: ./.github/workflows/build-linux-pkgs.yml
     with:
       plan: ${{ needs.plan.outputs.val }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,11 +147,21 @@ jobs:
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
 
+  custom-linux-arm:
+    needs:
+      - plan
+    if: ${{ needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload' }}
+    uses: ./.github/workflows/linux-arm.yml
+    with:
+      plan: ${{ needs.plan.outputs.val }}
+    secrets: inherit
+
   # Build and package all the platform-agnostic(ish) things
   build-global-artifacts:
     needs:
       - plan
       - build-local-artifacts
+      - custom-linux-arm
     runs-on: "ubuntu-20.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -194,6 +204,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
+      - custom-linux-arm
     uses: ./.github/workflows/build-linux-pkgs.yml
     with:
       plan: ${{ needs.plan.outputs.val }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,7 @@ pr-run-mode = "upload"
 publish-prereleases = true
 # Post-announce jobs to run in CI
 post-announce-jobs = ["./dotslash"]
-
-[[workspace.metadata.dist.extra-artifacts]]
-artifacts = ["target/dev-scope-aarch64-unknown-linux-gnu.tar.xz"]
-build = [".github/bin/build-with-cross.sh", "aarch64-unknown-linux-gnu"]
+local-artifacts-jobs = ["./linux-arm"]
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ global-artifacts-jobs = ["./build-linux-pkgs"]
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Publish jobs to run in CI
-pr-run-mode = "plan"
+pr-run-mode = "upload"
 # Whether to publish prereleases to package managers
 publish-prereleases = true
 # Post-announce jobs to run in CI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ global-artifacts-jobs = ["./build-linux-pkgs"]
 # Publish jobs to run in CI
 publish-jobs = ["homebrew"]
 # Publish jobs to run in CI
-pr-run-mode = "upload"
+pr-run-mode = "plan"
 # Whether to publish prereleases to package managers
 publish-prereleases = true
 # Post-announce jobs to run in CI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ publish-prereleases = true
 # Post-announce jobs to run in CI
 post-announce-jobs = ["./dotslash"]
 
-[workspace.metadata.dist.github-custom-runners]
-aarch64-unknown-linux-gnu = "buildjet-8vcpu-ubuntu-2204-arm"
-aarch64-unknown-linux-musl = "buildjet-8vcpu-ubuntu-2204-arm"
+[[workspace.metadata.dist.extra-artifacts]]
+artifacts = ["target/dev-scope-aarch64-unknown-linux-gnu.tar.xz"]
+build = [".github/bin/build-with-cross.sh", "aarch64-unknown-linux-gnu"]
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ pr-run-mode = "upload"
 publish-prereleases = true
 # Post-announce jobs to run in CI
 post-announce-jobs = ["./dotslash"]
-local-artifacts-jobs = ["./linux-arm"]
+local-artifacts-jobs = ["./build-linux-arm"]
 
 # The profile that 'cargo dist' will build with
 [profile.dist]


### PR DESCRIPTION
This will use `cargo cross` to build arm linux.

Tested in https://github.com/oscope-dev/scope/actions/runs/8382769107/job/22957337653?pr=87