### PR TITLE
Provide `working_dir` to check paths for shared configs

### DIFF
--- a/examples/.scope/doctor-group-templated.yaml
+++ b/examples/.scope/doctor-group-templated.yaml
@@ -1,0 +1,14 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: templated
+  description: Silence any app specific MOTDs
+spec:
+  actions:
+  - name: hushlogin
+    check:
+      paths:
+        - '{{ working_dir }}/.hushlogin'
+    fix:
+      commands:
+        - "touch .hushlogin"

--- a/scope/schema/merged.json
+++ b/scope/schema/merged.json
@@ -33,7 +33,7 @@
           "nullable": true
         },
         "paths": {
-          "description": "A list of globs to check for changes. When the glob matches a new file, or the contents of the file change, the check will require a fix.",
+          "description": "A list of globs to check for changes. When the glob matches a new file, or the contents of the file change, the check will require a fix.\n\nRelative paths are relative to the scope config directory containing the config file.\n\nShared configs can use the template string `{{ working_dir }}` to access the working directory.",
           "default": null,
           "type": [
             "array",

--- a/scope/schema/merged.json
+++ b/scope/schema/merged.json
@@ -194,7 +194,8 @@
           "default": {
             "scope.github.com/bin-path": null,
             "scope.github.com/file-dir": null,
-            "scope.github.com/file-path": null
+            "scope.github.com/file-path": null,
+            "working_dir": null
           },
           "$ref": "#/definitions/ModelMetadataAnnotations"
         },
@@ -222,6 +223,14 @@
       "properties": {
         "scope.github.com/bin-path": {
           "description": "When running commands, additional paths that should be paced at the _beginning_ of the `PATH`.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "nullable": true
+        },
+        "working_dir": {
+          "description": "The current working directory of the scope command, generated automatically.",
           "type": [
             "string",
             "null"

--- a/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -207,7 +207,8 @@
           "default": {
             "scope.github.com/bin-path": null,
             "scope.github.com/file-dir": null,
-            "scope.github.com/file-path": null
+            "scope.github.com/file-path": null,
+            "working_dir": null
           },
           "$ref": "#/definitions/ModelMetadataAnnotations"
         },
@@ -235,6 +236,14 @@
       "properties": {
         "scope.github.com/bin-path": {
           "description": "When running commands, additional paths that should be paced at the _beginning_ of the `PATH`.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "nullable": true
+        },
+        "working_dir": {
+          "description": "The current working directory of the scope command, generated automatically.",
           "type": [
             "string",
             "null"

--- a/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -46,7 +46,7 @@
           "nullable": true
         },
         "paths": {
-          "description": "A list of globs to check for changes. When the glob matches a new file, or the contents of the file change, the check will require a fix.",
+          "description": "A list of globs to check for changes. When the glob matches a new file, or the contents of the file change, the check will require a fix.\n\nRelative paths are relative to the scope config directory containing the config file.\n\nShared configs can use the template string `{{ working_dir }}` to access the working directory.",
           "default": null,
           "type": [
             "array",

--- a/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -207,7 +207,8 @@
           "default": {
             "scope.github.com/bin-path": null,
             "scope.github.com/file-dir": null,
-            "scope.github.com/file-path": null
+            "scope.github.com/file-path": null,
+            "working_dir": null
           },
           "$ref": "#/definitions/ModelMetadataAnnotations"
         },
@@ -235,6 +236,14 @@
       "properties": {
         "scope.github.com/bin-path": {
           "description": "When running commands, additional paths that should be paced at the _beginning_ of the `PATH`.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "nullable": true
+        },
+        "working_dir": {
+          "description": "The current working directory of the scope command, generated automatically.",
           "type": [
             "string",
             "null"

--- a/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -46,7 +46,7 @@
           "nullable": true
         },
         "paths": {
-          "description": "A list of globs to check for changes. When the glob matches a new file, or the contents of the file change, the check will require a fix.",
+          "description": "A list of globs to check for changes. When the glob matches a new file, or the contents of the file change, the check will require a fix.\n\nRelative paths are relative to the scope config directory containing the config file.\n\nShared configs can use the template string `{{ working_dir }}` to access the working directory.",
           "default": null,
           "type": [
             "array",

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportDefinition.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportDefinition.json
@@ -207,7 +207,8 @@
           "default": {
             "scope.github.com/bin-path": null,
             "scope.github.com/file-dir": null,
-            "scope.github.com/file-path": null
+            "scope.github.com/file-path": null,
+            "working_dir": null
           },
           "$ref": "#/definitions/ModelMetadataAnnotations"
         },
@@ -235,6 +236,14 @@
       "properties": {
         "scope.github.com/bin-path": {
           "description": "When running commands, additional paths that should be paced at the _beginning_ of the `PATH`.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "nullable": true
+        },
+        "working_dir": {
+          "description": "The current working directory of the scope command, generated automatically.",
           "type": [
             "string",
             "null"

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportDefinition.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportDefinition.json
@@ -46,7 +46,7 @@
           "nullable": true
         },
         "paths": {
-          "description": "A list of globs to check for changes. When the glob matches a new file, or the contents of the file change, the check will require a fix.",
+          "description": "A list of globs to check for changes. When the glob matches a new file, or the contents of the file change, the check will require a fix.\n\nRelative paths are relative to the scope config directory containing the config file.\n\nShared configs can use the template string `{{ working_dir }}` to access the working directory.",
           "default": null,
           "type": [
             "array",

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -207,7 +207,8 @@
           "default": {
             "scope.github.com/bin-path": null,
             "scope.github.com/file-dir": null,
-            "scope.github.com/file-path": null
+            "scope.github.com/file-path": null,
+            "working_dir": null
           },
           "$ref": "#/definitions/ModelMetadataAnnotations"
         },
@@ -235,6 +236,14 @@
       "properties": {
         "scope.github.com/bin-path": {
           "description": "When running commands, additional paths that should be paced at the _beginning_ of the `PATH`.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "nullable": true
+        },
+        "working_dir": {
+          "description": "The current working directory of the scope command, generated automatically.",
           "type": [
             "string",
             "null"

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -46,7 +46,7 @@
           "nullable": true
         },
         "paths": {
-          "description": "A list of globs to check for changes. When the glob matches a new file, or the contents of the file change, the check will require a fix.",
+          "description": "A list of globs to check for changes. When the glob matches a new file, or the contents of the file change, the check will require a fix.\n\nRelative paths are relative to the scope config directory containing the config file.\n\nShared configs can use the template string `{{ working_dir }}` to access the working directory.",
           "default": null,
           "type": [
             "array",

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -324,13 +324,11 @@ pub trait GlobWalker: Send + Sync {
 pub struct DefaultGlobWalker {}
 
 fn make_absolute(base_dir: &Path, glob: &String) -> String {
-    let result = if glob.starts_with("/") {
-        format!("{}", glob)
+    if glob.starts_with('/') {
+        glob.to_string()
     } else {
         format!("{}/{}", base_dir.display(), glob)
-    };
-
-    result
+    }
 }
 
 #[async_trait]

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -323,6 +323,16 @@ pub trait GlobWalker: Send + Sync {
 #[derive(Debug, Default)]
 pub struct DefaultGlobWalker {}
 
+fn make_absolute(base_dir: &Path, glob: &String) -> String {
+    let result = if glob.starts_with("/") {
+        format!("{}", glob)
+    } else {
+        format!("{}/{}", base_dir.display(), glob)
+    };
+
+    result
+}
+
 #[async_trait]
 impl GlobWalker for DefaultGlobWalker {
     async fn have_globs_changed(
@@ -335,7 +345,7 @@ impl GlobWalker for DefaultGlobWalker {
         use glob::glob;
 
         for glob_str in paths {
-            let glob_path = format!("{}/{}", base_dir.display(), glob_str);
+            let glob_path = make_absolute(base_dir, glob_str);
             for path in glob(&glob_path)?.filter_map(Result::ok) {
                 let file_result = file_cache.check_file(cache_name.to_string(), &path).await?;
                 let check_result = file_result == FileCacheStatus::FileMatches;

--- a/scope/src/models/core.rs
+++ b/scope/src/models/core.rs
@@ -19,6 +19,8 @@ pub struct ModelMetadataAnnotations {
     /// Directory containing the resource, generated automatically.
     pub file_dir: Option<String>,
     #[serde(rename = "scope.github.com/bin-path")]
+    /// When running commands, the working directory of the command
+    pub working_dir: Option<String>,
     /// When running commands, additional paths that should be paced at the _beginning_ of the `PATH`.
     pub bin_path: Option<String>,
     #[serde(flatten)]

--- a/scope/src/models/core.rs
+++ b/scope/src/models/core.rs
@@ -14,15 +14,19 @@ pub struct ModelMetadataAnnotations {
     #[schemars(skip)]
     /// File path for the resource, generated automatically.
     pub file_path: Option<String>,
+
     #[serde(rename = "scope.github.com/file-dir")]
     #[schemars(skip)]
     /// Directory containing the resource, generated automatically.
     pub file_dir: Option<String>,
-    #[serde(rename = "scope.github.com/bin-path")]
-    /// When running commands, the working directory of the command
+
+    /// The current working directory of the scope command, generated automatically.
     pub working_dir: Option<String>,
+
+    #[serde(rename = "scope.github.com/bin-path")]
     /// When running commands, additional paths that should be paced at the _beginning_ of the `PATH`.
     pub bin_path: Option<String>,
+
     #[serde(flatten)]
     pub extra: BTreeMap<String, String>,
 }

--- a/scope/src/models/v1alpha/doctor_group.rs
+++ b/scope/src/models/v1alpha/doctor_group.rs
@@ -15,6 +15,11 @@ pub struct DoctorCheckSpec {
     #[serde(default)]
     /// A list of globs to check for changes. When the glob matches a new file, or the contents
     /// of the file change, the check will require a fix.
+    ///
+    /// Relative paths are relative to the scope config directory containing the config file.
+    ///
+    /// Shared configs can use the template string `{{ working_dir }}` to access the working
+    /// directory.
     pub paths: Option<Vec<String>>,
 
     #[serde(default)]

--- a/scope/src/shared/config_load.rs
+++ b/scope/src/shared/config_load.rs
@@ -232,7 +232,7 @@ fn insert_if_absent<T: HelpMetadata>(map: &mut BTreeMap<String, T>, entry: T) {
     }
 }
 
-async fn load_all_config(working_dir: &PathBuf, paths: &Vec<PathBuf>) -> Vec<ModelRoot<Value>> {
+async fn load_all_config(working_dir: &Path, paths: &Vec<PathBuf>) -> Vec<ModelRoot<Value>> {
     let mut loaded_values = Vec::new();
 
     for file_path in expand_to_files(paths) {

--- a/scope/src/shared/config_load.rs
+++ b/scope/src/shared/config_load.rs
@@ -149,7 +149,7 @@ impl FoundConfig {
             .map(|x| x.join("bin").display().to_string())
             .join(":");
 
-        let mut raw_config = load_all_config(&config_path).await;
+        let mut raw_config = load_all_config(&working_dir, &config_path).await;
         raw_config.sort_by_key(|x| x.full_name());
 
         let mut this = Self {
@@ -232,7 +232,7 @@ fn insert_if_absent<T: HelpMetadata>(map: &mut BTreeMap<String, T>, entry: T) {
     }
 }
 
-async fn load_all_config(paths: &Vec<PathBuf>) -> Vec<ModelRoot<Value>> {
+async fn load_all_config(working_dir: &PathBuf, paths: &Vec<PathBuf>) -> Vec<ModelRoot<Value>> {
     let mut loaded_values = Vec::new();
 
     for file_path in expand_to_files(paths) {
@@ -244,7 +244,7 @@ async fn load_all_config(paths: &Vec<PathBuf>) -> Vec<ModelRoot<Value>> {
             Ok(content) => content,
         };
         for doc in Deserializer::from_str(&file_contents) {
-            if let Some(parsed_model) = parse_model(doc, &file_path) {
+            if let Some(parsed_model) = parse_model(doc, working_dir, &file_path) {
                 loaded_values.push(parsed_model)
             }
         }
@@ -253,7 +253,11 @@ async fn load_all_config(paths: &Vec<PathBuf>) -> Vec<ModelRoot<Value>> {
     loaded_values
 }
 
-pub(crate) fn parse_model(doc: Deserializer, file_path: &Path) -> Option<ModelRoot<Value>> {
+pub(crate) fn parse_model(
+    doc: Deserializer,
+    working_dir: &Path,
+    file_path: &Path,
+) -> Option<ModelRoot<Value>> {
     let value = match Value::deserialize(doc) {
         Ok(value) => value,
         Err(e) => {
@@ -270,6 +274,10 @@ pub(crate) fn parse_model(doc: Deserializer, file_path: &Path) -> Option<ModelRo
                 Some(file_path.parent().unwrap().display().to_string());
 
             value.metadata.annotations.bin_path = Some(build_exec_path(file_path));
+
+            // TODO: a better way to convert PathBuf to String?
+            value.metadata.annotations.working_dir =
+                Some(working_dir.to_str().unwrap().to_string());
             Some(value)
         }
         Err(e) => {

--- a/scope/src/shared/models/internal/doctor_group.rs
+++ b/scope/src/shared/models/internal/doctor_group.rs
@@ -213,9 +213,10 @@ mod tests {
     #[test]
     fn parse_group_1() {
         let test_file = format!("{}/examples/group-1.yaml", env!("CARGO_MANIFEST_DIR"));
+        let work_dir = Path::new("/foo/bar");
         let text = std::fs::read_to_string(test_file).unwrap();
         let path = Path::new("/foo/bar/.scope/file.yaml");
-        let configs = parse_models_from_string(path, &text).unwrap();
+        let configs = parse_models_from_string(work_dir, path, &text).unwrap();
         assert_eq!(1, configs.len());
 
         let dg = configs[0].get_doctor_group().unwrap();

--- a/scope/src/shared/models/internal/doctor_group.rs
+++ b/scope/src/shared/models/internal/doctor_group.rs
@@ -183,7 +183,7 @@ impl TryFrom<V1AlphaDoctorGroup> for DoctorGroup {
                     files: spec_action.check.paths.map(|paths| DoctorGroupCachePath {
                         paths: paths
                             .iter() // TODO: should this be as_ref() still? Changed because type inference error
-                            .map(|p| evaluate_path(working_dir.as_str(), p).unwrap()) // TODO: better error handling in map
+                            .map(|p| evaluate_path(working_dir.as_str(), p).unwrap()) // TODO: implement a function here, make it an early exit
                             .collect(),
                         base_path: containing_dir.parent().unwrap().to_path_buf(),
                     }),

--- a/scope/src/shared/models/internal/doctor_group.rs
+++ b/scope/src/shared/models/internal/doctor_group.rs
@@ -134,7 +134,7 @@ fn evaluate_path(work_dir: &str, path: &String) -> Result<String> {
     let mut env = Environment::new();
     env.add_template("path", path.as_str())?;
     let template = env.get_template("path")?;
-    let result = template.render(context! { work_dir => work_dir })?;
+    let result = template.render(context! { working_dir => work_dir })?;
 
     Ok(result)
 }

--- a/scope/src/shared/models/internal/doctor_group.rs
+++ b/scope/src/shared/models/internal/doctor_group.rs
@@ -130,9 +130,9 @@ impl HelpMetadata for DoctorGroup {
     }
 }
 
-fn evaluate_path(work_dir: &str, path: &String) -> Result<String> {
+fn evaluate_path(work_dir: &str, path: &str) -> Result<String> {
     let mut env = Environment::new();
-    env.add_template("path", path.as_str())?;
+    env.add_template("path", path)?;
     let template = env.get_template("path")?;
     let result = template.render(context! { working_dir => work_dir })?;
 

--- a/scope/src/shared/models/internal/known_error.rs
+++ b/scope/src/shared/models/internal/known_error.rs
@@ -58,7 +58,8 @@ spec:
   help: The command had an error, try reading the logs around there to find out what happened.";
 
         let path = Path::new("/foo/bar/file.yaml");
-        let configs = parse_models_from_string(path, text).unwrap();
+        let work_dir = Path::new("/foo/bar");
+        let configs = parse_models_from_string(work_dir, path, text).unwrap();
         assert_eq!(1, configs.len());
         let model = configs[0].get_known_error_spec().unwrap();
 

--- a/scope/src/shared/models/internal/report_definition.rs
+++ b/scope/src/shared/models/internal/report_definition.rs
@@ -56,7 +56,8 @@ spec:
  ";
 
         let path = Path::new("/foo/bar/file.yaml");
-        let configs = parse_models_from_string(path, text).unwrap();
+        let work_dir = Path::new("/foo/bar");
+        let configs = parse_models_from_string(work_dir, path, text).unwrap();
         assert_eq!(1, configs.len());
         let model = configs[0].get_report_def_spec().unwrap();
 

--- a/scope/src/shared/models/mod.rs
+++ b/scope/src/shared/models/mod.rs
@@ -6,6 +6,7 @@ pub mod prelude {
 
 #[cfg(test)]
 pub(crate) fn parse_models_from_string(
+    working_dir: &std::path::Path,
     file_path: &std::path::Path,
     input: &str,
 ) -> anyhow::Result<Vec<prelude::ParsedConfig>> {
@@ -13,7 +14,9 @@ pub(crate) fn parse_models_from_string(
 
     let mut models = Vec::new();
     for doc in Deserializer::from_str(input) {
-        if let Some(parsed_model) = crate::shared::config_load::parse_model(doc, file_path) {
+        if let Some(parsed_model) =
+            crate::shared::config_load::parse_model(doc, working_dir, file_path)
+        {
             models.push(parsed_model.try_into()?)
         }
     }

--- a/scope/tests/integration_tests.rs
+++ b/scope/tests/integration_tests.rs
@@ -218,6 +218,29 @@ fn test_run_group_1() {
 }
 
 #[test]
+fn test_run_templated() {
+    let working_dir = setup_working_dir();
+
+    let mut cmd = Command::cargo_bin("scope").unwrap();
+    let result = cmd
+        .current_dir(working_dir.path())
+        .env("SCOPE_RUN_ID", "test_run_templated")
+        .arg("doctor")
+        .arg("run")
+        .arg("--only=templated")
+        .arg(&format!(
+            "--cache-dir={}/.cache",
+            working_dir.to_str().unwrap()
+        ))
+        .env("NO_COLOR", "1")
+        .assert();
+
+    result.success().stdout(predicate::str::contains(
+        "Check was successful, group: \"templated\", name: \"hushlogin\"",
+    ));
+}
+
+#[test]
 fn test_no_tasks_found() {
     let working_dir = setup_working_dir();
 


### PR DESCRIPTION
## Problem
Currently, the ScopeDoctorGroup `action.check.paths` are relative to the scope config directory they are located in. This is problematic for shared configurations (i.e. stored in `/etc/scope/shared/*`) which need to check application files in the current working directory.

## Solution
Evaluate the path globs as templates which can access a `working_dir` variable.

## TODO
- [x] update documentation
- [x] ~~unit tests~~
- [x] (maybe) integration test