### PR TITLE
Expose scope's bin directory to action commands

### DIFF
--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -233,9 +233,9 @@ impl DefaultDoctorActionRun {
             std::env::current_exe()
                 .unwrap()
                 .parent()
-                .unwrap()
+                .expect("executable should be in a directory")
                 .to_str()
-                .unwrap()
+                .expect("bin directory should be a valid string")
                 .to_string(),
         );
         env_vars

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -492,7 +492,9 @@ pub(crate) mod tests {
         let mut counter = 0;
         mock.expect_run_command()
             .times(expected_results.len())
-            .withf(move |params| params.args[0].eq(command))
+            .withf(move |params| {
+                params.args[0].eq(command) && params.env_vars.contains_key("SCOPE_BIN_DIR")
+            })
             .returning(move |_| {
                 let resp_code = expected_results[counter];
                 counter += 1;


### PR DESCRIPTION
## Problem

To better support shared configurations, it would be useful to access the scope configuration directory from within a check or fix command. This would allow for the loading of shared scripts that implement standard library type functionality.

For example, in an application's `.scope/bin/some-fix.sh`:
```bash
. "${SCOPE_BIN_DIR}/../etc/scope/stdlib.sh"

usage "some-fix"
custom_function_2 
```

## Solution
Use `std::env::current_exe()` to make the bin directory available as `SCOPE_BIN_DIR`.

## TODO
- [x] tests