### PR TITLE
Fix caching for shared configs using templated paths

### DIFF
--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -416,7 +416,7 @@ impl GlobWalker for DefaultGlobWalker {
         use glob::glob;
 
         for glob_str in paths {
-            let glob_path = format!("{}/{}", base_dir.display(), glob_str);
+            let glob_path = make_absolute(base_dir, glob_str);
             for path in glob(&glob_path)?.filter_map(Result::ok) {
                 file_cache
                     .update_cache_entry(cache_name.to_string(), &path)


### PR DESCRIPTION
## Problem
I noticed shared checks that leverage `check.paths` were always running.

When `make_absolute` was added [previously](https://github.com/oscope-dev/scope/pull/88/files#diff-529964d30753ecb680a347e8f4206aa662ec4bbe17371931e5c27026118fcaa1R326), one usage of `format!("{}/{}", base_dir.display(), glob_str)` was left in the code. As a result, these paths were silently excluded from the cache:

```
{
  "checksums": {
    "dev-database": {
      "/Users/adam.neumann/workspace/hawaiian-ice/db/structure.sql": "abc123"
    }
  }
}
```

## Solution
Use `make_absolute` everywhere! After doing this, cache is populated as expected:
```
{
  "checksums": {
    "brewfile": {
      "/Users/adam.neumann/workspace/hawaiian-ice/Brewfile": "abc123"
    },
    "bundle-install": {
      "/Users/adam.neumann/workspace/hawaiian-ice/.ruby-version": "abc123",
      "/Users/adam.neumann/workspace/hawaiian-ice/Gemfile": "abc123",
      "/Users/adam.neumann/workspace/hawaiian-ice/Gemfile.lock": "abc123"
    },
    "dev-database": {
      "/Users/adam.neumann/workspace/hawaiian-ice/db/structure.sql": "abc123"
    },
    "yarn-install": {
      "/Users/adam.neumann/workspace/hawaiian-ice/package.json": "abc123",
      "/Users/adam.neumann/workspace/hawaiian-ice/yarn.lock": "abc123"
    }
  }
}
```