### PR TITLE
Canonicalize shared config paths

### DIFF
--- a/scope/src/shared/config_load.rs
+++ b/scope/src/shared/config_load.rs
@@ -141,7 +141,12 @@ impl FoundConfig {
 
         let mut config_path = config_path.to_vec();
         let exe_path = std::env::current_exe().unwrap();
-        let shared_path = exe_path.parent().unwrap().join("../etc/scope");
+        let shared_path = exe_path
+            .parent()
+            .unwrap()
+            .join("../etc/scope")
+            .canonicalize()
+            .expect("shared path to be canonicalizable");
         config_path.push(shared_path);
 
         let scope_path = config_path

--- a/scope/src/shared/config_load.rs
+++ b/scope/src/shared/config_load.rs
@@ -141,13 +141,13 @@ impl FoundConfig {
 
         let mut config_path = config_path.to_vec();
         let exe_path = std::env::current_exe().unwrap();
-        let shared_path = exe_path
-            .parent()
-            .unwrap()
-            .join("../etc/scope")
-            .canonicalize()
-            .expect("shared path to be canonicalizable");
-        config_path.push(shared_path);
+        let shared_path = exe_path.parent().unwrap().join("../etc/scope");
+        if shared_path.exists() {
+            let can_path = shared_path
+                .canonicalize()
+                .expect("shared path to be canonicalizable");
+            config_path.push(can_path);
+        }
 
         let scope_path = config_path
             .iter()


### PR DESCRIPTION
## Problem
When shared configs were being loaded, their paths were being shown including the `bin/../etc` string, which is unnecessary:
```
❯ scope doctor list
 INFO Available checks that will run
 INFO   Name                                          Description                                                 Path
 INFO - ScopeDoctorGroup/homebrew                     Homebrew                                                    ../gusto_scope/bin/../etc/scope/shared/environment/homebrew.yaml
 INFO - ScopeDoctorGroup/app                          Application setup                                           .scope/app.yaml
```

## Solution
Canonicalize the shared path before searching it for files. Now:
```
❯ scope doctor list
 INFO Available checks that will run
 INFO   Name                                          Description                                                 Path
 INFO - ScopeDoctorGroup/homebrew                     Homebrew                                                    ../gusto_scope/etc/scope/shared/environment/homebrew.yaml
 INFO - ScopeDoctorGroup/app                          Application setup                                           .scope/app.yaml
```