### PR TITLE
Fix group logs not being overwritten

### DIFF
--- a/scope/src/bin/scope-intercept.rs
+++ b/scope/src/bin/scope-intercept.rs
@@ -41,7 +41,8 @@ async fn main() -> anyhow::Result<()> {
     let (_guard, file_location) = opts
         .logging
         .with_new_default(tracing::level_filters::LevelFilter::WARN)
-        .configure_logging(&opts.config_options.get_run_id(), "intercept");
+        .configure_logging(&opts.config_options.get_run_id(), "intercept")
+        .await;
 
     let exit_code = run_command(opts).await.unwrap_or_else(|e| {
         error!(target: "user", "Fatal error {:?}", e);

--- a/scope/src/bin/scope.rs
+++ b/scope/src/bin/scope.rs
@@ -65,7 +65,8 @@ async fn main() {
 
     let (_guard, file_location) = opts
         .logging
-        .configure_logging(&opts.config.get_run_id(), "root");
+        .configure_logging(&opts.config.get_run_id(), "root")
+        .await;
     let error_code = run_subcommand(opts).await;
 
     if error_code != 0 || enabled!(Level::DEBUG) {

--- a/scope/src/shared/mod.rs
+++ b/scope/src/shared/mod.rs
@@ -22,7 +22,7 @@ pub mod prelude {
         MockExecutionProvider, OutputCapture, OutputCaptureBuilder, OutputDestination,
     };
     pub use super::config_load::{build_config_path, ConfigOptions, FoundConfig};
-    pub use super::logging::{progress_bar_without_pos, LoggingOpts};
+    pub use super::logging::{progress_bar_without_pos, LoggingOpts, STDERR_WRITER, STDOUT_WRITER};
     pub use super::models::prelude::*;
     pub use super::print_details;
     pub use super::report::ReportBuilder;


### PR DESCRIPTION
This will use a lock provided by IndicatifLayer to ensure that output doesn't get overwritten as the progress bars are displayed.

In order to ensure that STDOUT_WRITER and STDERR_WRITER are always available, they default to stdout and stderr respectively, then as logging is initialized they are replaced with the writer provided by IndicatifLayer, which under the hood uses a mutext when writing to the console.