### PR TITLE
Improve UX by reducing output

### DIFF
--- a/scope/src/doctor/commands/list.rs
+++ b/scope/src/doctor/commands/list.rs
@@ -1,18 +1,18 @@
 use crate::doctor::runner::compute_group_order;
+use crate::report_stdout;
 use crate::shared::prelude::{DoctorGroup, FoundConfig};
 use crate::shared::print_details;
 use anyhow::Result;
 use clap::Args;
 use std::collections::BTreeSet;
-use tracing::info;
 
 #[derive(Debug, Args)]
 pub struct DoctorListArgs {}
 
 pub async fn doctor_list(found_config: &FoundConfig, _args: &DoctorListArgs) -> Result<()> {
-    info!(target: "user", "Available checks that will run");
+    report_stdout!("Available checks that will run");
     let order = generate_doctor_list(found_config).clone();
-    print_details(&found_config.working_dir, &order);
+    print_details(&found_config.working_dir, &order).await;
     Ok(())
 }
 

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -87,13 +87,13 @@ where
 
                 match action_result {
                     ActionRunResult::CheckSucceeded => {
-                        info!(target: "user", group = group_name, name = action.name(), "Check was successful");
+                        info!(target: "progress", group = group_name, name = action.name(), "Check was successful");
                     }
                     ActionRunResult::NoCheckFixSucceeded => {
-                        info!(target: "user", group = group_name, name = action.name(), "Fix ran successfully");
+                        info!(target: "progress", group = group_name, name = action.name(), "Fix ran successfully");
                     }
                     ActionRunResult::CheckFailedFixSucceedVerifySucceed => {
-                        info!(target: "user", group = group_name, name = action.name(), "Check initially failed, fix was successful");
+                        info!(target: "progress", group = group_name, name = action.name(), "Check initially failed, fix was successful");
                     }
                     ActionRunResult::CheckFailedFixFailed => {
                         error!(target: "user", group = group_name, name = action.name(), "Check failed, fix ran and {}", "failed".red().bold());
@@ -102,7 +102,7 @@ where
                         error!(target: "user", group = group_name, name = action.name(), "Check initially failed, fix ran, verification {}", "failed".red().bold());
                     }
                     ActionRunResult::CheckFailedNoRunFix => {
-                        info!(target: "user", group = group_name, name = action.name(), "Check failed, fix was not run");
+                        info!(target: "progress", group = group_name, name = action.name(), "Check failed, fix was not run");
                     }
                     ActionRunResult::CheckFailedNoFixProvided => {
                         error!(target: "user", group = group_name, name = action.name(), "Check failed, no fix provided");

--- a/scope/src/lib.rs
+++ b/scope/src/lib.rs
@@ -11,3 +11,14 @@ pub mod prelude {
     pub use crate::report::prelude::*;
     pub use crate::shared::prelude::*;
 }
+
+/// Preferred way to output data to users. This macro will write the output to tracing for debugging
+/// and to stdout using the global stdout writer. Because we use the stdout writer, the calls
+/// will all be async.
+#[macro_export]
+macro_rules! report_stdout {
+    ($($arg:tt)*) => {
+        tracing::info!(target="stdout", $($arg)*);
+        writeln!($crate::prelude::STDOUT_WRITER.write().await, $($arg)*).ok()
+    };
+}

--- a/scope/src/shared/config_load.rs
+++ b/scope/src/shared/config_load.rs
@@ -18,7 +18,7 @@ use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 #[derive(Parser, Debug)]
 #[clap(group = ArgGroup::new("config"))]
@@ -221,7 +221,7 @@ impl FoundConfig {
                 if self.report_definition.is_none() {
                     self.report_definition.replace(report_definition);
                 } else {
-                    warn!(target: "user", "A ReportDefinition with duplicate name found, dropping ReportUpload {} in {}", report_definition.name(), report_definition.metadata().file_path());
+                    info!(target: "user", "A ReportDefinition with duplicate name found, dropping ReportUpload {} in {}", report_definition.name(), report_definition.metadata().file_path());
                 }
             }
         }
@@ -231,7 +231,7 @@ impl FoundConfig {
 fn insert_if_absent<T: HelpMetadata>(map: &mut BTreeMap<String, T>, entry: T) {
     let name = entry.name().to_string();
     if map.contains_key(&name) {
-        warn!(target: "user", "Duplicate {} found, dropping {} in {}", entry.full_name().to_string().bold(), entry.name().bold(), entry.metadata().file_path());
+        info!(target: "user", "Duplicate {} found, dropping {} in {}", entry.full_name().to_string().bold(), entry.name().bold(), entry.metadata().file_path());
     } else {
         map.insert(name.to_string(), entry);
     }

--- a/scope/src/shared/mod.rs
+++ b/scope/src/shared/mod.rs
@@ -1,9 +1,9 @@
 use colored::Colorize;
 
 use crate::models::HelpMetadata;
+use crate::report_stdout;
 use std::cmp::max;
 use std::path::Path;
-use tracing::info;
 
 mod capture;
 mod config_load;
@@ -33,7 +33,7 @@ pub(crate) fn convert_to_string(input: Vec<&str>) -> Vec<String> {
     input.iter().map(|x| x.to_string()).collect()
 }
 
-pub fn print_details<T>(working_dir: &Path, config: &Vec<T>)
+pub async fn print_details<T>(working_dir: &Path, config: &Vec<T>)
 where
     T: HelpMetadata,
 {
@@ -44,7 +44,12 @@ where
         .unwrap_or(20);
     let max_name_length = max(max_name_length, 20) + 2;
 
-    info!(target: "user", "  {:max_name_length$}{:60}{}", "Name".white().bold(), "Description".white().bold(), "Path".white().bold());
+    report_stdout!(
+        "  {:max_name_length$}{:60}{}",
+        "Name".white().bold(),
+        "Description".white().bold(),
+        "Path".white().bold()
+    );
     for resource in config {
         let mut description = resource.description().to_string();
         if description.len() > 55 {
@@ -60,6 +65,11 @@ where
             loc = format!("...{}", loc.split_off(loc.len() - 35));
         }
 
-        info!(target: "user", "- {:max_name_length$}{:60}{}", resource.full_name(), description, loc);
+        report_stdout!(
+            "- {:max_name_length$}{:60}{}",
+            resource.full_name(),
+            description,
+            loc
+        );
     }
 }


### PR DESCRIPTION
The goal of this code is to enable `--progress` as a root logging option. By default, if `scope` is run within a `tty` then the only real output should be progress bar updates.

This change also removes many of the logging options to support only `-v / --verbose` option. By default we'll log much less.

With this, we're able to write to stdout without needing to go through tracing, removing some of the formatting requirements.

With this change, we're adding support for `report_stdout!` which will allow developers to write to stdout. This returns a future, so all calls need to be `async`. It will also "log" the line, so the output will show up in logs.

## Output

New CLI options

```
Options:
  -v, --verbose...
          A level of verbosity, and can be used multiple times

      --progress <PROGRESS>
          Set the progress output. Use plain to disable updating UI

          [env: SCOPE_OUTPUT_PROGRESS=]
          [default: auto]

          Possible values:
          - auto:  Determine output format based on execution context
          - plain: Standard output, no progress bar, no auto-updating output
          - tty:   Use progress bar

```