### PR TITLE
Allow groups to configure task resolution

### DIFF
--- a/docs/docs/models/ScopeDoctorGroup.mdx
+++ b/docs/docs/models/ScopeDoctorGroup.mdx
@@ -22,6 +22,7 @@ kind: ScopeDoctorGroup
 metadata:
   name: node
 spec:
+  include: by-default
   description: Check node is ready.
   needs:
     - python

--- a/scope/examples/group-1.yaml
+++ b/scope/examples/group-1.yaml
@@ -3,6 +3,7 @@ kind: ScopeDoctorGroup
 metadata:
   name: foo
 spec:
+  include: when-required
   description: Check your shell for basic functionality
   needs:
     - bar

--- a/scope/examples/v1alpha/DoctorGroup.yaml
+++ b/scope/examples/v1alpha/DoctorGroup.yaml
@@ -2,8 +2,9 @@ apiVersion: scope.github.com/v1alpha
 kind: ScopeDoctorGroup
 metadata:
   name: foo
-spec:
   description: Check your shell for basic functionality
+spec:
+  include: by-default
   needs:
     - bar
   actions:

--- a/scope/examples/v1alpha/KnownError.yaml
+++ b/scope/examples/v1alpha/KnownError.yaml
@@ -2,7 +2,7 @@ apiVersion: scope.github.com/v1alpha
 kind: ScopeKnownError
 metadata:
   name: error-exists
-spec:
   description: Check if the word error is in the logs
+spec:
   pattern: error
   help: The command had an error, try reading the logs around there to find out what happened.

--- a/scope/schema/merged.json
+++ b/scope/schema/merged.json
@@ -147,6 +147,11 @@
             "$ref": "#/definitions/DoctorGroupActionSpec"
           }
         },
+        "include": {
+          "description": "Change how a group is handled when building the dependency task graph. When set to `when-required`, the group will be ignored unless it's required by another dependency.",
+          "default": "by-default",
+          "$ref": "#/definitions/DoctorInclude"
+        },
         "needs": {
           "description": "A list of `ScopeDoctorGroup` that are required for this group to execute. If not all finish successfully, this group will not execute.",
           "default": [],
@@ -157,6 +162,25 @@
         }
       },
       "additionalProperties": false
+    },
+    "DoctorInclude": {
+      "description": "Configure how a groups will be used when determining the task graph.",
+      "oneOf": [
+        {
+          "description": "Default option, the group will be included by default when determining which groups should run.",
+          "type": "string",
+          "enum": [
+            "by-default"
+          ]
+        },
+        {
+          "description": "Useful for shared configuration. The group will not run unless another group depends on it.",
+          "type": "string",
+          "enum": [
+            "when-required"
+          ]
+        }
+      ]
     },
     "KnownErrorKind": {
       "type": "string",

--- a/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -160,6 +160,11 @@
             "$ref": "#/definitions/DoctorGroupActionSpec"
           }
         },
+        "include": {
+          "description": "Change how a group is handled when building the dependency task graph. When set to `when-required`, the group will be ignored unless it's required by another dependency.",
+          "default": "by-default",
+          "$ref": "#/definitions/DoctorInclude"
+        },
         "needs": {
           "description": "A list of `ScopeDoctorGroup` that are required for this group to execute. If not all finish successfully, this group will not execute.",
           "default": [],
@@ -170,6 +175,25 @@
         }
       },
       "additionalProperties": false
+    },
+    "DoctorInclude": {
+      "description": "Configure how a groups will be used when determining the task graph.",
+      "oneOf": [
+        {
+          "description": "Default option, the group will be included by default when determining which groups should run.",
+          "type": "string",
+          "enum": [
+            "by-default"
+          ]
+        },
+        {
+          "description": "Useful for shared configuration. The group will not run unless another group depends on it.",
+          "type": "string",
+          "enum": [
+            "when-required"
+          ]
+        }
+      ]
     },
     "KnownErrorKind": {
       "type": "string",

--- a/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -160,6 +160,11 @@
             "$ref": "#/definitions/DoctorGroupActionSpec"
           }
         },
+        "include": {
+          "description": "Change how a group is handled when building the dependency task graph. When set to `when-required`, the group will be ignored unless it's required by another dependency.",
+          "default": "by-default",
+          "$ref": "#/definitions/DoctorInclude"
+        },
         "needs": {
           "description": "A list of `ScopeDoctorGroup` that are required for this group to execute. If not all finish successfully, this group will not execute.",
           "default": [],
@@ -170,6 +175,25 @@
         }
       },
       "additionalProperties": false
+    },
+    "DoctorInclude": {
+      "description": "Configure how a groups will be used when determining the task graph.",
+      "oneOf": [
+        {
+          "description": "Default option, the group will be included by default when determining which groups should run.",
+          "type": "string",
+          "enum": [
+            "by-default"
+          ]
+        },
+        {
+          "description": "Useful for shared configuration. The group will not run unless another group depends on it.",
+          "type": "string",
+          "enum": [
+            "when-required"
+          ]
+        }
+      ]
     },
     "KnownErrorKind": {
       "type": "string",

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportDefinition.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportDefinition.json
@@ -160,6 +160,11 @@
             "$ref": "#/definitions/DoctorGroupActionSpec"
           }
         },
+        "include": {
+          "description": "Change how a group is handled when building the dependency task graph. When set to `when-required`, the group will be ignored unless it's required by another dependency.",
+          "default": "by-default",
+          "$ref": "#/definitions/DoctorInclude"
+        },
         "needs": {
           "description": "A list of `ScopeDoctorGroup` that are required for this group to execute. If not all finish successfully, this group will not execute.",
           "default": [],
@@ -170,6 +175,25 @@
         }
       },
       "additionalProperties": false
+    },
+    "DoctorInclude": {
+      "description": "Configure how a groups will be used when determining the task graph.",
+      "oneOf": [
+        {
+          "description": "Default option, the group will be included by default when determining which groups should run.",
+          "type": "string",
+          "enum": [
+            "by-default"
+          ]
+        },
+        {
+          "description": "Useful for shared configuration. The group will not run unless another group depends on it.",
+          "type": "string",
+          "enum": [
+            "when-required"
+          ]
+        }
+      ]
     },
     "KnownErrorKind": {
       "type": "string",

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -160,6 +160,11 @@
             "$ref": "#/definitions/DoctorGroupActionSpec"
           }
         },
+        "include": {
+          "description": "Change how a group is handled when building the dependency task graph. When set to `when-required`, the group will be ignored unless it's required by another dependency.",
+          "default": "by-default",
+          "$ref": "#/definitions/DoctorInclude"
+        },
         "needs": {
           "description": "A list of `ScopeDoctorGroup` that are required for this group to execute. If not all finish successfully, this group will not execute.",
           "default": [],
@@ -170,6 +175,25 @@
         }
       },
       "additionalProperties": false
+    },
+    "DoctorInclude": {
+      "description": "Configure how a groups will be used when determining the task graph.",
+      "oneOf": [
+        {
+          "description": "Default option, the group will be included by default when determining which groups should run.",
+          "type": "string",
+          "enum": [
+            "by-default"
+          ]
+        },
+        {
+          "description": "Useful for shared configuration. The group will not run unless another group depends on it.",
+          "type": "string",
+          "enum": [
+            "when-required"
+          ]
+        }
+      ]
     },
     "KnownErrorKind": {
       "type": "string",

--- a/scope/src/doctor/commands/list.rs
+++ b/scope/src/doctor/commands/list.rs
@@ -1,10 +1,12 @@
+use std::collections::BTreeSet;
+
+use anyhow::Result;
+use clap::Args;
+
 use crate::doctor::runner::compute_group_order;
 use crate::report_stdout;
 use crate::shared::prelude::{DoctorGroup, FoundConfig};
 use crate::shared::print_details;
-use anyhow::Result;
-use clap::Args;
-use std::collections::BTreeSet;
 
 #[derive(Debug, Args)]
 pub struct DoctorListArgs {}
@@ -17,7 +19,13 @@ pub async fn doctor_list(found_config: &FoundConfig, _args: &DoctorListArgs) -> 
 }
 
 pub fn generate_doctor_list(found_config: &FoundConfig) -> Vec<DoctorGroup> {
-    let all_keys = BTreeSet::from_iter(found_config.doctor_group.keys().map(|x| x.to_string()));
+    let all_keys = BTreeSet::from_iter(
+        found_config
+            .doctor_group
+            .iter()
+            .filter(|(_, v)| v.run_by_default)
+            .map(|(k, _)| k.to_string()),
+    );
     let group_order = compute_group_order(&found_config.doctor_group, all_keys);
 
     group_order

--- a/scope/src/doctor/tests.rs
+++ b/scope/src/doctor/tests.rs
@@ -1,6 +1,7 @@
+use std::collections::BTreeMap;
+
 use crate::models::prelude::{ModelMetadataAnnotations, ModelMetadataBuilder};
 use crate::shared::prelude::{DoctorGroup, DoctorGroupAction, DoctorGroupBuilder};
-use std::collections::BTreeMap;
 
 pub fn make_root_model_additional<Meta, Group>(
     actions: Vec<DoctorGroupAction>,
@@ -24,7 +25,8 @@ where
         .full_name("DoctorGroup/fake-name")
         .actions(actions)
         .metadata(metadata)
-        .requires(Vec::new());
+        .requires(Vec::new())
+        .run_by_default(true);
 
     edit_group(group_builder).build().unwrap()
 }

--- a/scope/src/shared/models/internal/doctor_group.rs
+++ b/scope/src/shared/models/internal/doctor_group.rs
@@ -1,10 +1,13 @@
-use crate::models::prelude::{ModelMetadata, V1AlphaDoctorGroup};
-use crate::models::HelpMetadata;
-use crate::shared::models::internal::extract_command_path;
+use std::path::{Path, PathBuf};
+
 use anyhow::Result;
 use derive_builder::Builder;
 use minijinja::{context, Environment};
-use std::path::{Path, PathBuf};
+
+use crate::models::prelude::{ModelMetadata, V1AlphaDoctorGroup};
+use crate::models::HelpMetadata;
+use crate::prelude::DoctorInclude;
+use crate::shared::models::internal::extract_command_path;
 
 #[derive(Debug, PartialEq, Clone, Builder)]
 #[builder(setter(into))]
@@ -117,6 +120,7 @@ pub struct DoctorGroup {
     pub full_name: String,
     pub metadata: ModelMetadata,
     pub requires: Vec<String>,
+    pub run_by_default: bool,
     pub actions: Vec<DoctorGroupAction>,
 }
 
@@ -196,19 +200,20 @@ impl TryFrom<V1AlphaDoctorGroup> for DoctorGroup {
             metadata: model.metadata,
             actions,
             requires: model.spec.needs,
+            run_by_default: model.spec.include == DoctorInclude::ByDefault,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use crate::shared::models::parse_models_from_string;
     use crate::shared::models::prelude::{
         DoctorGroupAction, DoctorGroupActionCheck, DoctorGroupActionCommand, DoctorGroupActionFix,
     };
     use crate::shared::prelude::DoctorGroupCachePath;
-
-    use std::path::Path;
 
     #[test]
     fn parse_group_1() {


### PR DESCRIPTION
DoctorGroup will have an optional field `include` that will determine if the group should be included by default when determine task to run.

The `include` option has no effect if `--only` is used.

The default behavior is to include the group; however in the case where there are shared configs, the shared configs will now specify `include: when-required` and create a "root" group that declares all the groups that are required for the app.