### PR TITLE
Include summary at end of doctor run

### DIFF
--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -433,7 +433,7 @@ mod tests {
         };
 
         let exit_code = run_groups.execute().await?;
-        assert_eq!(0, exit_code);
+        assert_eq!(true, exit_code.did_succeed);
 
         Ok(())
     }
@@ -458,7 +458,7 @@ mod tests {
         };
 
         let exit_code = run_groups.execute().await?;
-        assert_eq!(1, exit_code);
+        assert_eq!(false, exit_code.did_succeed);
 
         Ok(())
     }
@@ -491,7 +491,7 @@ mod tests {
         };
 
         let exit_code = run_groups.execute().await?;
-        assert_eq!(1, exit_code);
+        assert_eq!(false, exit_code.did_succeed);
 
         Ok(())
     }

--- a/scope/tests/integration_tests.rs
+++ b/scope/tests/integration_tests.rs
@@ -61,7 +61,7 @@ impl<'a> ScopeTestHelper<'a> {
         self.run_command(&run_command)
     }
 
-    fn clean_work_dir(mut self) {
+    fn clean_work_dir(self) {
         self.work_dir.close().unwrap();
     }
 }


### PR DESCRIPTION
When `scope doctor run` finishes, it will print the number of groups that succeeded, failed, and were skipped. This will allow people to know that something was done.

This also fixes a bug, where the progress bar would be stuck at the max length instead of counting up showing progress / percent complete

# Example Output
(with error)
<img width="602" alt="image" src="https://github.com/oscope-dev/scope/assets/794802/b38245aa-45ae-47b3-aa7f-e2e8fc3f8646">
(with error and skip)
<img width="725" alt="image" src="https://github.com/oscope-dev/scope/assets/794802/cd7b0b22-0823-4820-acea-aac0378529db">
