### PR TITLE
Load env vars from a shared config location

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -55,3 +55,10 @@ Options:
 ```
 
 Normally, you will not need to set any of these files.
+
+## Environment Variables
+
+Scope will load environment variables in this order of presedence:
+
+1. `../etc/scope.env` relative to where the executable is located
+1. `.env` in the current working directory

--- a/scope/src/bin/scope-intercept.rs
+++ b/scope/src/bin/scope-intercept.rs
@@ -36,6 +36,9 @@ struct Cli {
 async fn main() -> anyhow::Result<()> {
     setup_panic!();
     dotenv::dotenv().ok();
+    let exe_path = std::env::current_exe().unwrap();
+    let env_path = exe_path.parent().unwrap().join("../etc/scope.env");
+    dotenv::from_path(env_path).ok();
     let opts = Cli::parse();
 
     let (_guard, file_location) = opts

--- a/scope/src/bin/scope.rs
+++ b/scope/src/bin/scope.rs
@@ -62,6 +62,9 @@ enum Command {
 async fn main() {
     setup_panic!();
     dotenv::dotenv().ok();
+    let exe_path = std::env::current_exe().unwrap();
+    let env_path = exe_path.parent().unwrap().join("../etc/scope.env");
+    dotenv::from_path(env_path).ok();
     let opts = Cli::parse();
 
     let (_guard, file_location) = opts


### PR DESCRIPTION
This PR makes it possible for scope to load environment variables from a "shared" .env file. This is helpful for scope developers that need to deploy credentials (i.e. GitHub App or GitHub tokens) to app engineers.

## Testing
With a clean env and a `../etc/scope.env` file populated with a `GH_TOKEN`, I was able to submit a report:
```
❯ bin/scope report -- echo foobar
 INFO Report was uploaded to https://github.com/Gusto/gusto_scope_testing/issues/4.
```

Removing this file caused `scope report` to fail with the expected configuration error:
```
❯ bin/scope report -- echo foobar
 WARN Unable to upload to github: GH_TOKEN env var was not set with token to access GitHub
```