### PR TITLE
Replace dotenv with dotenvy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
  "derivative",
  "derive_builder",
  "directories",
- "dotenv",
+ "dotenvy",
  "educe",
  "escargot",
  "glob",
@@ -641,10 +641,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "downcast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ lto = "thin"
 clap = { version = "4.5.4", features = ["derive", "env"]}
 human-panic = "1.2.3"
 tokio = { version = "1", features = ["full"] }
-dotenv = "0.15.0"
 colored = "2.1.0"
 which = { version = "6.0", features = ["regex"] }
 regex = "1.10.4"
@@ -78,3 +77,4 @@ octocrab = "0.38.0"
 jsonwebtoken = "9.3.0"
 secrecy = "0.8.0"
 url = "2.5.0"
+dotenvy = "0.15.7"

--- a/scope/Cargo.toml
+++ b/scope/Cargo.toml
@@ -29,7 +29,6 @@ name = "scope-intercept"
 clap.workspace = true
 human-panic.workspace = true
 tokio.workspace = true
-dotenv.workspace = true
 colored.workspace = true
 which.workspace = true
 regex.workspace = true
@@ -72,6 +71,7 @@ octocrab.workspace = true
 jsonwebtoken.workspace = true
 secrecy.workspace = true
 url.workspace = true
+dotenvy.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/scope/src/bin/scope-intercept.rs
+++ b/scope/src/bin/scope-intercept.rs
@@ -35,10 +35,10 @@ struct Cli {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     setup_panic!();
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
     let exe_path = std::env::current_exe().unwrap();
     let env_path = exe_path.parent().unwrap().join("../etc/scope.env");
-    dotenv::from_path(env_path).ok();
+    dotenvy::from_path(env_path).ok();
     let opts = Cli::parse();
 
     let (_guard, file_location) = opts

--- a/scope/src/bin/scope.rs
+++ b/scope/src/bin/scope.rs
@@ -61,10 +61,11 @@ enum Command {
 #[tokio::main]
 async fn main() {
     setup_panic!();
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
     let exe_path = std::env::current_exe().unwrap();
     let env_path = exe_path.parent().unwrap().join("../etc/scope.env");
-    dotenv::from_path(env_path).ok();
+    dotenvy::from_path(env_path).ok();
+    dbg!(dotenvy::vars());
     let opts = Cli::parse();
 
     let (_guard, file_location) = opts


### PR DESCRIPTION
dotenv appears unmaintained and [does not support multiline values](https://github.com/dotenv-rs/dotenv/pull/63) yet. Replace this with a the well maintained fork [dotenvy](https://crates.io/crates/dotenvy).

## Testing
Ran `scope doctor run` locally and confirmed it successfully reads multi-line env vars correctly.