### PR TITLE
Product a report from `scope doctor run`

### DIFF
--- a/scope/src/bin/scope-intercept.rs
+++ b/scope/src/bin/scope-intercept.rs
@@ -109,7 +109,7 @@ async fn run_command(opts: Cli) -> anyhow::Result<i32> {
         )
         .prompt();
 
-    let report_builder = ReportBuilder::new(&capture, &found_config).await?;
+    let report_builder = ReportBuilder::new_from_error(&capture, &found_config).await?;
     if let Ok(true) = ans {
         if let Err(e) = report_builder.distribute_report(&found_config).await {
             warn!(target: "user", "Unable to upload report: {}", e);

--- a/scope/src/bin/scope-intercept.rs
+++ b/scope/src/bin/scope-intercept.rs
@@ -109,7 +109,8 @@ async fn run_command(opts: Cli) -> anyhow::Result<i32> {
         )
         .prompt();
 
-    let report_builder = ReportBuilder::new_from_error(&capture, &found_config).await?;
+    let title = format!("Scope bug report: `{:?}`", command);
+    let report_builder = ReportBuilder::new_from_error(title, &capture, &found_config).await?;
     if let Ok(true) = ans {
         if let Err(e) = report_builder.distribute_report(&found_config).await {
             warn!(target: "user", "Unable to upload report: {}", e);

--- a/scope/src/bin/scope-intercept.rs
+++ b/scope/src/bin/scope-intercept.rs
@@ -111,7 +111,7 @@ async fn run_command(opts: Cli) -> anyhow::Result<i32> {
 
     let report_builder = ReportBuilder::new(&capture, &found_config).await?;
     if let Ok(true) = ans {
-        if let Err(e) = report_builder.distribute_report().await {
+        if let Err(e) = report_builder.distribute_report(&found_config).await {
             warn!(target: "user", "Unable to upload report: {}", e);
         }
     } else {

--- a/scope/src/bin/scope.rs
+++ b/scope/src/bin/scope.rs
@@ -65,7 +65,6 @@ async fn main() {
     let exe_path = std::env::current_exe().unwrap();
     let env_path = exe_path.parent().unwrap().join("../etc/scope.env");
     dotenvy::from_path(env_path).ok();
-    dbg!(dotenvy::vars());
     let opts = Cli::parse();
 
     let (_guard, file_location) = opts

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -5,7 +5,7 @@ use std::cmp::max;
 use std::collections::BTreeMap;
 
 use crate::models::HelpMetadata;
-use crate::prelude::progress_bar_without_pos;
+use crate::prelude::{progress_bar_without_pos, ReportBuilder};
 use crate::shared::prelude::{
     CaptureError, CaptureOpts, DoctorGroup, DoctorGroupAction, DoctorGroupActionCommand,
     DoctorGroupCachePath, ExecutionProvider, OutputDestination,
@@ -86,7 +86,7 @@ impl ActionRunResult {
 #[automock]
 #[async_trait::async_trait]
 pub trait DoctorActionRun: Send + Sync {
-    async fn run_action(&self) -> Result<ActionRunResult>;
+    async fn run_action(&self, report: &mut ReportBuilder) -> Result<ActionRunResult>;
     fn required(&self) -> bool;
     fn name(&self) -> String;
     fn help_text(&self) -> Option<String>;
@@ -111,7 +111,7 @@ pub struct DefaultDoctorActionRun {
 #[async_trait::async_trait]
 impl DoctorActionRun for DefaultDoctorActionRun {
     #[instrument(skip_all, fields(model.name = self.model.name(), action.name = self.action.name, action.description = self.action.description ))]
-    async fn run_action(&self) -> Result<ActionRunResult> {
+    async fn run_action(&self, report: &mut ReportBuilder) -> Result<ActionRunResult> {
         let action_span = info_span!("action", "indicatif.pb_show" = true);
         action_span.pb_set_message(&format!(
             "action {} - {}",
@@ -120,7 +120,7 @@ impl DoctorActionRun for DefaultDoctorActionRun {
         action_span.pb_set_style(&progress_bar_without_pos());
         let _span = action_span.enter();
 
-        let check_status = self.evaluate_checks().await?;
+        let check_status = self.evaluate_checks(report).await?;
         if check_status == CacheResults::FixNotRequired {
             return Ok(ActionRunResult::CheckSucceeded);
         }
@@ -129,7 +129,7 @@ impl DoctorActionRun for DefaultDoctorActionRun {
             return Ok(ActionRunResult::CheckFailedNoRunFix);
         }
 
-        let fix_result = self.run_fixes().await?;
+        let fix_result = self.run_fixes(report).await?;
 
         match fix_result {
             i32::MIN..=-1 => {
@@ -145,7 +145,7 @@ impl DoctorActionRun for DefaultDoctorActionRun {
             return Ok(ActionRunResult::NoCheckFixSucceeded);
         }
 
-        if let Some(check_status) = self.evaluate_command_checks().await? {
+        if let Some(check_status) = self.evaluate_command_checks(report).await? {
             if check_status != CacheResults::FixNotRequired {
                 return Ok(ActionRunResult::CheckFailedFixSucceedVerifyFailed);
             }
@@ -193,11 +193,11 @@ impl DefaultDoctorActionRun {
         }
     }
 
-    async fn run_fixes(&self) -> Result<i32, RuntimeError> {
+    async fn run_fixes(&self, report: &mut ReportBuilder) -> Result<i32, RuntimeError> {
         let mut highest_exit_code = -1;
         if let Some(action_command) = &self.action.fix.command {
             for command in &action_command.commands {
-                let result = self.run_single_fix(command).await?;
+                let result = self.run_single_fix(command, report).await?;
                 highest_exit_code = max(highest_exit_code, result);
                 if highest_exit_code >= 100 {
                     return Ok(highest_exit_code);
@@ -208,7 +208,11 @@ impl DefaultDoctorActionRun {
         Ok(highest_exit_code)
     }
 
-    async fn run_single_fix(&self, command: &str) -> Result<i32, RuntimeError> {
+    async fn run_single_fix(
+        &self,
+        command: &str,
+        report: &mut ReportBuilder,
+    ) -> Result<i32, RuntimeError> {
         let args = vec![command.to_string()];
         let capture = self
             .exec_runner
@@ -220,6 +224,8 @@ impl DefaultDoctorActionRun {
                 env_vars: self.generate_env_vars(),
             })
             .await?;
+
+        report.add_capture(&capture)?;
 
         info!("fix ran {} and exited {:?}", command, capture.exit_code);
 
@@ -241,7 +247,10 @@ impl DefaultDoctorActionRun {
         env_vars
     }
 
-    async fn evaluate_checks(&self) -> Result<CacheResults, RuntimeError> {
+    async fn evaluate_checks(
+        &self,
+        report: &mut ReportBuilder,
+    ) -> Result<CacheResults, RuntimeError> {
         let mut path_check = None;
         let mut command_check = None;
         if let Some(cache_path) = &self.action.check.files {
@@ -253,7 +262,7 @@ impl DefaultDoctorActionRun {
             path_check = Some(result);
         }
 
-        if let Some(res) = self.evaluate_command_checks().await? {
+        if let Some(res) = self.evaluate_command_checks(report).await? {
             if !res.is_success() {
                 return Ok(res);
             }
@@ -271,9 +280,12 @@ impl DefaultDoctorActionRun {
         }
     }
 
-    async fn evaluate_command_checks(&self) -> Result<Option<CacheResults>, RuntimeError> {
+    async fn evaluate_command_checks(
+        &self,
+        report: &mut ReportBuilder,
+    ) -> Result<Option<CacheResults>, RuntimeError> {
         if let Some(action_command) = &self.action.check.command {
-            let result = self.run_check_command(action_command).await?;
+            let result = self.run_check_command(action_command, report).await?;
             return Ok(Some(result));
         }
 
@@ -304,6 +316,7 @@ impl DefaultDoctorActionRun {
     async fn run_check_command(
         &self,
         action_command: &DoctorGroupActionCommand,
+        report: &mut ReportBuilder,
     ) -> Result<CacheResults, RuntimeError> {
         info!("Evaluating {:?}", action_command);
         let mut result: Option<CacheResults> = None;
@@ -324,6 +337,8 @@ impl DefaultDoctorActionRun {
                     env_vars: self.generate_env_vars(),
                 })
                 .await?;
+
+            report.add_capture(&output)?;
 
             info!(
                 "check ran command {} and result was {:?}",
@@ -566,7 +581,8 @@ pub(crate) mod tests {
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        let result = run.run_action().await?;
+        // TODO: use automock for report builder here
+        let result = run.run_action(&mut ReportBuilder::blank()).await?;
         assert_eq!(ActionRunResult::CheckSucceeded, result);
 
         Ok(())
@@ -583,7 +599,7 @@ pub(crate) mod tests {
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        let result = run.run_action().await?;
+        let result = run.run_action(&mut ReportBuilder::blank()).await?;
         assert_eq!(ActionRunResult::CheckFailedFixSucceedVerifySucceed, result);
 
         Ok(())
@@ -600,7 +616,7 @@ pub(crate) mod tests {
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        let result = run.run_action().await?;
+        let result = run.run_action(&mut ReportBuilder::blank()).await?;
         assert_eq!(ActionRunResult::CheckFailedFixSucceedVerifyFailed, result);
 
         Ok(())
@@ -617,7 +633,7 @@ pub(crate) mod tests {
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        let result = run.run_action().await?;
+        let result = run.run_action(&mut ReportBuilder::blank()).await?;
         assert_eq!(ActionRunResult::CheckFailedFixFailed, result);
 
         Ok(())
@@ -643,7 +659,7 @@ pub(crate) mod tests {
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        let result = run.run_action().await?;
+        let result = run.run_action(&mut ReportBuilder::blank()).await?;
         assert_eq!(ActionRunResult::CheckFailedFixSucceedVerifySucceed, result);
 
         Ok(())
@@ -669,7 +685,7 @@ pub(crate) mod tests {
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        let result = run.run_action().await?;
+        let result = run.run_action(&mut ReportBuilder::blank()).await?;
         assert_eq!(ActionRunResult::CheckFailedFixSucceedVerifySucceed, result);
 
         Ok(())
@@ -691,7 +707,7 @@ pub(crate) mod tests {
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        let result = run.run_action().await?;
+        let result = run.run_action(&mut ReportBuilder::blank()).await?;
         assert_eq!(ActionRunResult::CheckFailedFixFailed, result);
 
         Ok(())

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -576,7 +576,7 @@ pub(crate) mod tests {
         let action = build_run_fail_fix_succeed_action();
         let mut exec_runner = MockExecutionProvider::new();
         let glob_walker = MockGlobWalker::new();
-        let mut report = ReportBuilder::blank();
+        let mut report = ReportBuilder::new_blank();
 
         command_result(&mut exec_runner, "check", vec![0]);
 
@@ -593,7 +593,7 @@ pub(crate) mod tests {
         let action = build_run_fail_fix_succeed_action();
         let mut exec_runner = MockExecutionProvider::new();
         let glob_walker = MockGlobWalker::new();
-        let mut report = ReportBuilder::blank();
+        let mut report = ReportBuilder::new_blank();
 
         command_result(&mut exec_runner, "check", vec![1, 0]);
         command_result(&mut exec_runner, "fix", vec![0]);
@@ -611,7 +611,7 @@ pub(crate) mod tests {
         let action = build_run_fail_fix_succeed_action();
         let mut exec_runner = MockExecutionProvider::new();
         let glob_walker = MockGlobWalker::new();
-        let mut report = ReportBuilder::blank();
+        let mut report = ReportBuilder::new_blank();
 
         command_result(&mut exec_runner, "check", vec![1, 1]);
         command_result(&mut exec_runner, "fix", vec![0]);
@@ -629,7 +629,7 @@ pub(crate) mod tests {
         let action = build_run_fail_fix_succeed_action();
         let mut exec_runner = MockExecutionProvider::new();
         let glob_walker = MockGlobWalker::new();
-        let mut report = ReportBuilder::blank();
+        let mut report = ReportBuilder::new_blank();
 
         command_result(&mut exec_runner, "check", vec![1]);
         command_result(&mut exec_runner, "fix", vec![1]);
@@ -647,7 +647,7 @@ pub(crate) mod tests {
         let action = build_file_fix_action();
         let mut glob_walker = MockGlobWalker::new();
         let mut exec_runner = MockExecutionProvider::new();
-        let mut report = ReportBuilder::blank();
+        let mut report = ReportBuilder::new_blank();
 
         command_result(&mut exec_runner, "fix", vec![0]);
 
@@ -673,7 +673,7 @@ pub(crate) mod tests {
         let action = build_file_fix_action();
         let mut glob_walker = MockGlobWalker::new();
         let mut exec_runner = MockExecutionProvider::new();
-        let mut report = ReportBuilder::blank();
+        let mut report = ReportBuilder::new_blank();
 
         command_result(&mut exec_runner, "fix", vec![0]);
 
@@ -699,7 +699,7 @@ pub(crate) mod tests {
         let action = build_file_fix_action();
         let mut exec_runner = MockExecutionProvider::new();
         let mut glob_walker = MockGlobWalker::new();
-        let mut report = ReportBuilder::blank();
+        let mut report = ReportBuilder::new_blank();
 
         command_result(&mut exec_runner, "fix", vec![1]);
 

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -576,7 +576,7 @@ pub(crate) mod tests {
         let action = build_run_fail_fix_succeed_action();
         let mut exec_runner = MockExecutionProvider::new();
         let glob_walker = MockGlobWalker::new();
-        let mut report = ReportBuilder::new_blank();
+        let mut report = ReportBuilder::new_blank("Test".to_string());
 
         command_result(&mut exec_runner, "check", vec![0]);
 
@@ -593,7 +593,7 @@ pub(crate) mod tests {
         let action = build_run_fail_fix_succeed_action();
         let mut exec_runner = MockExecutionProvider::new();
         let glob_walker = MockGlobWalker::new();
-        let mut report = ReportBuilder::new_blank();
+        let mut report = ReportBuilder::new_blank("Test".to_string());
 
         command_result(&mut exec_runner, "check", vec![1, 0]);
         command_result(&mut exec_runner, "fix", vec![0]);
@@ -611,7 +611,7 @@ pub(crate) mod tests {
         let action = build_run_fail_fix_succeed_action();
         let mut exec_runner = MockExecutionProvider::new();
         let glob_walker = MockGlobWalker::new();
-        let mut report = ReportBuilder::new_blank();
+        let mut report = ReportBuilder::new_blank("Test".to_string());
 
         command_result(&mut exec_runner, "check", vec![1, 1]);
         command_result(&mut exec_runner, "fix", vec![0]);
@@ -629,7 +629,7 @@ pub(crate) mod tests {
         let action = build_run_fail_fix_succeed_action();
         let mut exec_runner = MockExecutionProvider::new();
         let glob_walker = MockGlobWalker::new();
-        let mut report = ReportBuilder::new_blank();
+        let mut report = ReportBuilder::new_blank("Test".to_string());
 
         command_result(&mut exec_runner, "check", vec![1]);
         command_result(&mut exec_runner, "fix", vec![1]);
@@ -647,7 +647,7 @@ pub(crate) mod tests {
         let action = build_file_fix_action();
         let mut glob_walker = MockGlobWalker::new();
         let mut exec_runner = MockExecutionProvider::new();
-        let mut report = ReportBuilder::new_blank();
+        let mut report = ReportBuilder::new_blank("Test".to_string());
 
         command_result(&mut exec_runner, "fix", vec![0]);
 
@@ -673,7 +673,7 @@ pub(crate) mod tests {
         let action = build_file_fix_action();
         let mut glob_walker = MockGlobWalker::new();
         let mut exec_runner = MockExecutionProvider::new();
-        let mut report = ReportBuilder::new_blank();
+        let mut report = ReportBuilder::new_blank("Test".to_string());
 
         command_result(&mut exec_runner, "fix", vec![0]);
 
@@ -699,7 +699,7 @@ pub(crate) mod tests {
         let action = build_file_fix_action();
         let mut exec_runner = MockExecutionProvider::new();
         let mut glob_walker = MockGlobWalker::new();
-        let mut report = ReportBuilder::new_blank();
+        let mut report = ReportBuilder::new_blank("Test".to_string());
 
         command_result(&mut exec_runner, "fix", vec![1]);
 

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -576,13 +576,13 @@ pub(crate) mod tests {
         let action = build_run_fail_fix_succeed_action();
         let mut exec_runner = MockExecutionProvider::new();
         let glob_walker = MockGlobWalker::new();
+        let mut report = ReportBuilder::blank();
 
         command_result(&mut exec_runner, "check", vec![0]);
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        // TODO: use automock for report builder here
-        let result = run.run_action(&mut ReportBuilder::blank()).await?;
+        let result = run.run_action(&mut report).await?;
         assert_eq!(ActionRunResult::CheckSucceeded, result);
 
         Ok(())
@@ -593,13 +593,14 @@ pub(crate) mod tests {
         let action = build_run_fail_fix_succeed_action();
         let mut exec_runner = MockExecutionProvider::new();
         let glob_walker = MockGlobWalker::new();
+        let mut report = ReportBuilder::blank();
 
         command_result(&mut exec_runner, "check", vec![1, 0]);
         command_result(&mut exec_runner, "fix", vec![0]);
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        let result = run.run_action(&mut ReportBuilder::blank()).await?;
+        let result = run.run_action(&mut report).await?;
         assert_eq!(ActionRunResult::CheckFailedFixSucceedVerifySucceed, result);
 
         Ok(())
@@ -610,13 +611,14 @@ pub(crate) mod tests {
         let action = build_run_fail_fix_succeed_action();
         let mut exec_runner = MockExecutionProvider::new();
         let glob_walker = MockGlobWalker::new();
+        let mut report = ReportBuilder::blank();
 
         command_result(&mut exec_runner, "check", vec![1, 1]);
         command_result(&mut exec_runner, "fix", vec![0]);
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        let result = run.run_action(&mut ReportBuilder::blank()).await?;
+        let result = run.run_action(&mut report).await?;
         assert_eq!(ActionRunResult::CheckFailedFixSucceedVerifyFailed, result);
 
         Ok(())
@@ -627,13 +629,14 @@ pub(crate) mod tests {
         let action = build_run_fail_fix_succeed_action();
         let mut exec_runner = MockExecutionProvider::new();
         let glob_walker = MockGlobWalker::new();
+        let mut report = ReportBuilder::blank();
 
         command_result(&mut exec_runner, "check", vec![1]);
         command_result(&mut exec_runner, "fix", vec![1]);
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        let result = run.run_action(&mut ReportBuilder::blank()).await?;
+        let result = run.run_action(&mut report).await?;
         assert_eq!(ActionRunResult::CheckFailedFixFailed, result);
 
         Ok(())
@@ -642,9 +645,9 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_file_cache_invalid_fix_works() -> Result<()> {
         let action = build_file_fix_action();
-
         let mut glob_walker = MockGlobWalker::new();
         let mut exec_runner = MockExecutionProvider::new();
+        let mut report = ReportBuilder::blank();
 
         command_result(&mut exec_runner, "fix", vec![0]);
 
@@ -659,7 +662,7 @@ pub(crate) mod tests {
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        let result = run.run_action(&mut ReportBuilder::blank()).await?;
+        let result = run.run_action(&mut report).await?;
         assert_eq!(ActionRunResult::CheckFailedFixSucceedVerifySucceed, result);
 
         Ok(())
@@ -668,9 +671,9 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_file_cache_invalid_fix_works_unable_to_update_cache() -> Result<()> {
         let action = build_file_fix_action();
-
         let mut glob_walker = MockGlobWalker::new();
         let mut exec_runner = MockExecutionProvider::new();
+        let mut report = ReportBuilder::blank();
 
         command_result(&mut exec_runner, "fix", vec![0]);
 
@@ -685,7 +688,7 @@ pub(crate) mod tests {
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        let result = run.run_action(&mut ReportBuilder::blank()).await?;
+        let result = run.run_action(&mut report).await?;
         assert_eq!(ActionRunResult::CheckFailedFixSucceedVerifySucceed, result);
 
         Ok(())
@@ -696,6 +699,7 @@ pub(crate) mod tests {
         let action = build_file_fix_action();
         let mut exec_runner = MockExecutionProvider::new();
         let mut glob_walker = MockGlobWalker::new();
+        let mut report = ReportBuilder::blank();
 
         command_result(&mut exec_runner, "fix", vec![1]);
 
@@ -707,7 +711,7 @@ pub(crate) mod tests {
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
-        let result = run.run_action(&mut ReportBuilder::blank()).await?;
+        let result = run.run_action(&mut report).await?;
         assert_eq!(ActionRunResult::CheckFailedFixFailed, result);
 
         Ok(())

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -68,6 +68,24 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
         warn!(target: "user", "Unable to update cache, re-runs may redo work");
     }
 
+    if !result.did_succeed && !found_config.report_upload.is_empty() {
+        let mut report_builder = result.report.clone();
+
+        let ans = inquire::Confirm::new("Do you want to upload a bug report?")
+            .with_default(true)
+            .with_help_message(
+                "This will allow you to share the error with other engineers for support.",
+            )
+            .prompt();
+
+        if let Ok(true) = ans {
+            report_builder.add_additional_data(found_config).await?;
+            if let Err(e) = report_builder.distribute_report(found_config).await {
+                warn!(target: "user", "Unable to upload report: {}", e);
+            }
+        }
+    }
+
     if result.did_succeed {
         Ok(0)
     } else {

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -69,7 +69,7 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
     }
 
     if !result.did_succeed && !found_config.report_upload.is_empty() {
-        println!("");
+        println!();
         let ans = inquire::Confirm::new("Do you want to upload a bug report?")
             .with_default(true)
             .with_help_message(

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -69,8 +69,7 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
     }
 
     if !result.did_succeed && !found_config.report_upload.is_empty() {
-        let mut report_builder = result.report.clone();
-
+        println!("");
         let ans = inquire::Confirm::new("Do you want to upload a bug report?")
             .with_default(true)
             .with_help_message(
@@ -79,8 +78,7 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
             .prompt();
 
         if let Ok(true) = ans {
-            report_builder.add_additional_data(found_config).await?;
-            if let Err(e) = report_builder.distribute_report(found_config).await {
+            if let Err(e) = result.report.distribute_report(found_config).await {
                 warn!(target: "user", "Unable to upload report: {}", e);
             }
         }

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -1,4 +1,5 @@
 use super::check::{ActionRunResult, DoctorActionRun};
+use crate::prelude::ReportBuilder;
 use crate::shared::prelude::DoctorGroup;
 use anyhow::Result;
 use colored::Colorize;
@@ -10,12 +11,13 @@ use std::fmt::{Display, Formatter};
 use tracing::{debug, error, info, info_span, warn, Span};
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PathRunResult {
     pub did_succeed: bool,
     pub succeeded_groups: BTreeSet<String>,
     pub failed_group: BTreeSet<String>,
     pub skipped_group: BTreeSet<String>,
+    pub report: ReportBuilder,
 }
 
 impl Display for PathRunResult {
@@ -81,6 +83,7 @@ where
             succeeded_groups: BTreeSet::new(),
             failed_group: BTreeSet::new(),
             skipped_group: BTreeSet::new(),
+            report: ReportBuilder::blank(),
         };
 
         for (group_name, actions) in path {
@@ -105,7 +108,7 @@ where
                     continue;
                 }
 
-                let action_result = action.run_action().await?;
+                let action_result = action.run_action(&mut run_result.report).await?;
 
                 match action_result {
                     ActionRunResult::CheckSucceeded => {
@@ -392,7 +395,7 @@ mod tests {
     fn make_action_run(result: ActionRunResult) -> Vec<MockDoctorActionRun> {
         let mut run = MockDoctorActionRun::new();
         run.expect_run_action()
-            .returning(move || Ok(result.clone()));
+            .returning(move |_| Ok(result.clone()));
         run.expect_help_text().return_const(None);
         run.expect_help_url().return_const(None);
         run.expect_name().returning(|| "foo".to_string());

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -435,7 +435,7 @@ mod tests {
         };
 
         let exit_code = run_groups.execute().await?;
-        assert_eq!(true, exit_code.did_succeed);
+        assert!(exit_code.did_succeed);
 
         Ok(())
     }
@@ -460,7 +460,7 @@ mod tests {
         };
 
         let exit_code = run_groups.execute().await?;
-        assert_eq!(false, exit_code.did_succeed);
+        assert!(!exit_code.did_succeed);
 
         Ok(())
     }
@@ -493,7 +493,7 @@ mod tests {
         };
 
         let exit_code = run_groups.execute().await?;
-        assert_eq!(false, exit_code.did_succeed);
+        assert!(!exit_code.did_succeed);
 
         Ok(())
     }

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -83,7 +83,7 @@ where
             succeeded_groups: BTreeSet::new(),
             failed_group: BTreeSet::new(),
             skipped_group: BTreeSet::new(),
-            report: ReportBuilder::blank(),
+            report: ReportBuilder::new_blank(),
         };
 
         for (group_name, actions) in path {

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -83,7 +83,7 @@ where
             succeeded_groups: BTreeSet::new(),
             failed_group: BTreeSet::new(),
             skipped_group: BTreeSet::new(),
-            report: ReportBuilder::new_blank(),
+            report: ReportBuilder::new_blank("Scope bug report: `scope doctor run`".to_string()),
         };
 
         for (group_name, actions) in path {

--- a/scope/src/report/cli.rs
+++ b/scope/src/report/cli.rs
@@ -26,7 +26,7 @@ pub async fn report_root(found_config: &FoundConfig, args: &ReportArgs) -> Resul
     })
     .await?;
     let exit_code = capture.exit_code.unwrap_or(-1);
-    let report_builder = ReportBuilder::new(&capture, found_config).await?;
+    let report_builder = ReportBuilder::new_from_error(&capture, found_config).await?;
 
     if found_config.report_upload.is_empty() {
         report_builder.write_local_report()?;

--- a/scope/src/report/cli.rs
+++ b/scope/src/report/cli.rs
@@ -26,7 +26,9 @@ pub async fn report_root(found_config: &FoundConfig, args: &ReportArgs) -> Resul
     })
     .await?;
     let exit_code = capture.exit_code.unwrap_or(-1);
-    let report_builder = ReportBuilder::new_from_error(&capture, found_config).await?;
+
+    let title = format!("Scope bug report: `{:?}`", args.command);
+    let report_builder = ReportBuilder::new_from_error(title, &capture, found_config).await?;
 
     if found_config.report_upload.is_empty() {
         report_builder.write_local_report()?;

--- a/scope/src/report/cli.rs
+++ b/scope/src/report/cli.rs
@@ -33,7 +33,7 @@ pub async fn report_root(found_config: &FoundConfig, args: &ReportArgs) -> Resul
         return Ok(exit_code);
     }
 
-    if let Err(e) = report_builder.distribute_report().await {
+    if let Err(e) = report_builder.distribute_report(found_config).await {
         warn!(target: "user", "Unable to upload report: {}", e);
     }
 

--- a/scope/src/shared/config_load.rs
+++ b/scope/src/shared/config_load.rs
@@ -103,7 +103,7 @@ impl ConfigOptions {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct FoundConfig {
     pub working_dir: PathBuf,
     pub raw_config: Vec<ModelRoot<Value>>,

--- a/scope/src/shared/config_load.rs
+++ b/scope/src/shared/config_load.rs
@@ -103,7 +103,7 @@ impl ConfigOptions {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct FoundConfig {
     pub working_dir: PathBuf,
     pub raw_config: Vec<ModelRoot<Value>>,


### PR DESCRIPTION
Now that `scope doctor run` output is dynamic, running the output through `scope logs analyze` requires some flags. It'd be great if a report could just be created if `doctor run` fails.

This PR will introduce that behavior:
> When `scope doctor run` fails and a report location is present, a report will be generated and distributed.

The biggest changes here are:
- to expose more methods on `ReportBuilder`, enabling a report to be "built up" progressively
- update `DefaultDoctorActionRun.run_action` to accept a ReportBuilder, which is built up incrementally with each check and fix output
- make the report title an explicit argument when the report is created

## Testing
Tested this manually by using an always failing check and a test GitHub repo report location.

### A report location

After running `bin/scope doctor run --only always-fail`, this output was produced:
```
❯ bin/scope doctor run --only always-fail
ERROR Check failed, fix ran and failed, group: "always-fail", name: "exit 1"
Summary: 0 groups succeeded, 1 groups failed

> Do you want to upload a bug report? Yes
 INFO Report was uploaded to https://github.com/Gusto/gusto_scope_testing/issues/7.
```

and [this report](https://github.com/Gusto/gusto_scope_testing/issues/7) was created:
![Screenshot 2024-04-11 at 4 36 37 PM](https://github.com/oscope-dev/scope/assets/1007983/7eb5fd20-4005-4000-922d-96434a4fa5bd)

### No report location
```
❯ bin/scope doctor run --only always-fail
ERROR Check failed, fix ran and failed, group: "always-fail", name: "exit 1"
Summary: 0 groups succeeded, 1 groups failed
```