### PR TITLE
Include report additional data in doctor run generated report

### DIFF
--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -78,7 +78,13 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
             .prompt();
 
         if let Ok(true) = ans {
-            if let Err(e) = result.report.distribute_report(found_config).await {
+            let mut report = result.report.clone();
+
+            if let Err(e) = report.add_additional_data(found_config).await {
+                warn!(target: "user", "Unable to add additional data to bug report: {}", e);
+            }
+
+            if let Err(e) = report.distribute_report(found_config).await {
                 warn!(target: "user", "Unable to upload report: {}", e);
             }
         }

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -58,7 +58,7 @@ impl<'a> ReportBuilder {
         Ok(())
     }
 
-    async fn add_additional_data(&mut self, config: &'a FoundConfig) -> Result<()> {
+    pub async fn add_additional_data(&mut self, config: &'a FoundConfig) -> Result<()> {
         for command in config.get_report_definition().additional_data.values() {
             let args: Vec<String> = command.split(' ').map(|x| x.to_string()).collect();
             let capture = OutputCapture::capture_output(CaptureOpts {


### PR DESCRIPTION
The automatically generated reports in `scope doctor run` miss out on the useful debugging information from any found `ScopeReportDefinition`.

This PR adds that additional data to the report, safely handling the case where there is no report definition found.

Closes https://github.com/Gusto/dev-environments/issues/471

## Testing

Ran `bin/scope doctor run --only always-fail` and confirmed the [report](https://github.com/Gusto/gusto_scope_testing/issues/12) included additional data:
![Screenshot 2024-04-19 at 4 05 45 PM](https://github.com/oscope-dev/scope/assets/1007983/dbdc08f2-e38a-48c1-b4d2-a19755ec81b3)

