### PR TITLE
Adjust command results in bug report

### DIFF
--- a/scope/src/shared/capture.rs
+++ b/scope/src/shared/capture.rs
@@ -253,21 +253,9 @@ impl OutputCapture {
         writeln!(&mut f, "```")?;
         writeln!(&mut f)?;
 
-        writeln!(
-            &mut f,
-            "- Exit code: `{}`",
-            self.exit_code.unwrap_or(-1)
-        )?;
-        writeln!(
-            &mut f,
-            "- Started at: `{}`",
-            self.start_time
-        )?;
-        writeln!(
-            &mut f,
-            "- Finished at: `{}`",
-            self.end_time
-        )?;
+        writeln!(&mut f, "- Exit code: `{}`", self.exit_code.unwrap_or(-1))?;
+        writeln!(&mut f, "- Started at: `{}`", self.start_time)?;
+        writeln!(&mut f, "- Finished at: `{}`", self.end_time)?;
 
         Ok(f)
     }

--- a/scope/src/shared/capture.rs
+++ b/scope/src/shared/capture.rs
@@ -245,25 +245,30 @@ impl OutputCapture {
 
     pub fn create_report_text(&self) -> anyhow::Result<String> {
         let mut f = String::new();
-        writeln!(&mut f, "### Command Results\n")?;
-        writeln!(&mut f, "Ran command `/usr/bin/env -S {}`", self.command)?;
-        writeln!(
-            &mut f,
-            "Execution started: {}; finished: {}",
-            self.start_time, self.end_time
-        )?;
-        writeln!(
-            &mut f,
-            "Result of command: {}",
-            self.exit_code.unwrap_or(-1)
-        )?;
+        writeln!(&mut f, "### `{}`", self.command)?;
         writeln!(&mut f)?;
-        writeln!(&mut f, "#### Output")?;
-        writeln!(&mut f)?;
+
         writeln!(&mut f, "```text")?;
         writeln!(&mut f, "{}", self.generate_output().trim())?;
         writeln!(&mut f, "```")?;
         writeln!(&mut f)?;
+
+        writeln!(
+            &mut f,
+            "- Exit code: `{}`",
+            self.exit_code.unwrap_or(-1)
+        )?;
+        writeln!(
+            &mut f,
+            "- Started at: `{}`",
+            self.start_time
+        )?;
+        writeln!(
+            &mut f,
+            "- Finished at: `{}`",
+            self.end_time
+        )?;
+
         Ok(f)
     }
 

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -101,7 +101,7 @@ impl<'a> ReportBuilder {
             .clone()
             .map_or("".to_string(), |m| format!("{}\n\n", m));
 
-        format!("{}## Captured Data\n\n{}", top, self.command_results)
+        format!("{}## Captured Data\n{}", top, self.command_results)
     }
 
     pub async fn distribute_report(&self, config: &'a FoundConfig) -> Result<()> {


### PR DESCRIPTION
After reading a few bug reports, I found the output a bit difficult to grok. This PR:
1. moves the command to the heading element and drops the `/usr/bin/env -S` prefix
2. removes the output header
3. turns the command attributes into a list
4. separate all sections by a single new line

Example: https://gist.github.com/noizwaves/221082992d00fe235dfedc519ece5468