### PR TITLE
Handle additional data command error

### DIFF
--- a/examples/.scope/report.yaml
+++ b/examples/.scope/report.yaml
@@ -24,7 +24,7 @@ metadata:
   name: template
 spec:
   additionalData:
-    username: id -u
+    username: id -nu
     ruby: which ruby
     node: which node
     nodeVersion: node -v

--- a/examples/.scope/report.yaml
+++ b/examples/.scope/report.yaml
@@ -30,5 +30,5 @@ spec:
     nodeVersion: node -v
   template: |
     # There was an error!
-    
+
     When running `{{ command }}` scope ran into an error

--- a/scope/src/shared/capture.rs
+++ b/scope/src/shared/capture.rs
@@ -115,7 +115,6 @@ impl CaptureError {
         writeln!(&mut f, "```text")?;
         writeln!(&mut f, "CaptureError: {}", self)?;
         writeln!(&mut f, "```")?;
-        writeln!(&mut f)?;
         Ok(f)
     }
 }

--- a/scope/src/shared/capture.rs
+++ b/scope/src/shared/capture.rs
@@ -106,6 +106,21 @@ pub enum CaptureError {
     },
 }
 
+impl CaptureError {
+    pub fn create_report_text(&self, command: &String) -> anyhow::Result<String> {
+        let mut f = String::new();
+        writeln!(&mut f, "### `{}`", command)?;
+        writeln!(&mut f)?;
+
+        writeln!(&mut f, "*Error running command*")?;
+        writeln!(&mut f, "```text")?;
+        writeln!(&mut f, "{}", self)?;
+        writeln!(&mut f, "```")?;
+        writeln!(&mut f)?;
+        Ok(f)
+    }
+}
+
 #[automock]
 #[async_trait]
 pub trait ExecutionProvider: Send + Sync {

--- a/scope/src/shared/capture.rs
+++ b/scope/src/shared/capture.rs
@@ -113,7 +113,7 @@ impl CaptureError {
         writeln!(&mut f)?;
 
         writeln!(&mut f, "```text")?;
-        writeln!(&mut f, "{}", self)?;
+        writeln!(&mut f, "CaptureError: {}", self)?;
         writeln!(&mut f, "```")?;
         writeln!(&mut f)?;
         Ok(f)

--- a/scope/src/shared/capture.rs
+++ b/scope/src/shared/capture.rs
@@ -112,7 +112,6 @@ impl CaptureError {
         writeln!(&mut f, "### `{}`", command)?;
         writeln!(&mut f)?;
 
-        writeln!(&mut f, "*Error running command*")?;
         writeln!(&mut f, "```text")?;
         writeln!(&mut f, "{}", self)?;
         writeln!(&mut f, "```")?;

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -1,4 +1,4 @@
-use super::capture::{CaptureOpts, OutputCapture, CaptureError};
+use super::capture::{CaptureError, CaptureOpts, OutputCapture};
 use super::config_load::FoundConfig;
 use super::models::prelude::ReportUploadLocationDestination;
 use super::prelude::OutputDestination;
@@ -50,20 +50,20 @@ impl<'a> ReportBuilder {
         }
     }
 
-    pub fn add_capture(&mut self, capture: &outputcapture) -> result<()> {
+    pub fn add_capture(&mut self, capture: &OutputCapture) -> Result<()> {
         self.command_results.push('\n');
         self.command_results
             .push_str(&capture.create_report_text()?);
 
-        ok(())
+        Ok(())
     }
 
-    pub fn add_capture_error(&mut self, error: &CaptureError, command: &String) -> result<()> {
+    pub fn add_capture_error(&mut self, error: &CaptureError, command: &String) -> Result<()> {
         self.command_results.push('\n');
         self.command_results
             .push_str(&error.create_report_text(command)?);
 
-        ok(())
+        Ok(())
     }
 
     pub async fn add_additional_data(&mut self, config: &'a FoundConfig) -> Result<()> {
@@ -80,9 +80,8 @@ impl<'a> ReportBuilder {
 
             match result {
                 Ok(capture) => self.add_capture(&capture)?,
-                Err(error) => self.add_capture_error(&error, command)?
+                Err(error) => self.add_capture_error(&error, command)?,
             }
-
         }
 
         Ok(())


### PR DESCRIPTION
Previously, if an additional data command failed to run, `scope` would terminate without sending a report.

This PR adds explicit error handling to this case, and adds the error information into the report itself, [here's an example](https://gist.github.com/noizwaves/be12fb8e84d85cbc75cfe65d8907212d).

