### PR TITLE
Refactor report generation for group report extras

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,7 @@ dependencies = [
  "minijinja",
  "mockall",
  "nanoid",
+ "normpath",
  "octocrab",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -1777,6 +1778,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "normpath"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5831952a9476f2fed74b77d74182fa5ddc4d21c72ec45a333b250e3ed0272804"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,3 +84,4 @@ tracing-opentelemetry = "0.23.0"
 opentelemetry_sdk = { version = "0.22.1", features = ["metrics", "rt-tokio"] }
 tonic = "0.11.0"
 gethostname = "0.4.3"
+normpath = "1.2.0"

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,2 @@
+path-exists
+.hushlogin

--- a/examples/.scope/doctor-group-fail.yaml
+++ b/examples/.scope/doctor-group-fail.yaml
@@ -1,0 +1,18 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: fail
+  description: Sleep then fail
+spec:
+  include: when-required
+  reportExtraDetails:
+    who am i: id
+  actions:
+    - name: file-exists
+      check:
+        commands:
+          - echo "found file {{ working_dir }}/file-mod.txt"
+          - test -f {{ working_dir }}/file-mod.txt
+      fix:
+        commands:
+          - echo {{ working_dir }}/file-mod.txt

--- a/examples/.scope/report.yaml
+++ b/examples/.scope/report.yaml
@@ -1,22 +1,22 @@
----
-apiVersion: scope.github.com/v1alpha
-kind: ScopeReportLocation
-metadata:
-  name: report
-spec:
-  destination:
-    rustyPaste:
-      url: http://localhost:8000
----
-apiVersion: scope.github.com/v1alpha
-kind: ScopeReportLocation
-metadata:
-  name: github
-spec:
-  destination:
-    githubIssue:
-      owner: ethankhall
-      repo: dummy-repo
+#---
+#apiVersion: scope.github.com/v1alpha
+#kind: ScopeReportLocation
+#metadata:
+#  name: report
+#spec:
+#  destination:
+#    rustyPaste:
+#      url: http://localhost:8000
+#---
+#apiVersion: scope.github.com/v1alpha
+#kind: ScopeReportLocation
+#metadata:
+#  name: github
+#spec:
+#  destination:
+#    githubIssue:
+#      owner: ethankhall
+#      repo: dummy-repo
 ---
 apiVersion: scope.github.com/v1alpha
 kind: ScopeReportDefinition
@@ -32,3 +32,12 @@ spec:
     # There was an error!
 
     When running `{{ command }}` scope ran into an error
+---
+apiVersion: scope.github.com/v1alpha
+kind: ScopeReportLocation
+metadata:
+  name: local
+spec:
+  destination:
+    local:
+      directory: /tmp/scope/foo/

--- a/scope/Cargo.toml
+++ b/scope/Cargo.toml
@@ -78,6 +78,7 @@ tracing-opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 tonic.workspace = true
 gethostname.workspace = true
+normpath.workspace = true
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/scope/schema/merged.json
+++ b/scope/schema/merged.json
@@ -159,6 +159,14 @@
           "items": {
             "type": "string"
           }
+        },
+        "reportExtraDetails": {
+          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `additionalData` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/scope/schema/merged.json
+++ b/scope/schema/merged.json
@@ -326,6 +326,20 @@
       },
       "additionalProperties": false
     },
+    "ReportDestinationLocalSpec": {
+      "description": "Create a report that is only local",
+      "type": "object",
+      "required": [
+        "directory"
+      ],
+      "properties": {
+        "directory": {
+          "description": "Directory to put the report into",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "ReportDestinationRustyPasteSpec": {
       "description": "How to upload a report to RustyPaste",
       "type": "object",
@@ -362,6 +376,18 @@
           "properties": {
             "githubIssue": {
               "$ref": "#/definitions/ReportDestinationGithubIssueSpec"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "local"
+          ],
+          "properties": {
+            "local": {
+              "$ref": "#/definitions/ReportDestinationLocalSpec"
             }
           },
           "additionalProperties": false

--- a/scope/schema/merged.json
+++ b/scope/schema/merged.json
@@ -161,7 +161,7 @@
           }
         },
         "reportExtraDetails": {
-          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `additionalData` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
+          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `reportExtraDetails` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
           "default": {},
           "type": "object",
           "additionalProperties": {

--- a/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -339,6 +339,20 @@
       },
       "additionalProperties": false
     },
+    "ReportDestinationLocalSpec": {
+      "description": "Create a report that is only local",
+      "type": "object",
+      "required": [
+        "directory"
+      ],
+      "properties": {
+        "directory": {
+          "description": "Directory to put the report into",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "ReportDestinationRustyPasteSpec": {
       "description": "How to upload a report to RustyPaste",
       "type": "object",
@@ -375,6 +389,18 @@
           "properties": {
             "githubIssue": {
               "$ref": "#/definitions/ReportDestinationGithubIssueSpec"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "local"
+          ],
+          "properties": {
+            "local": {
+              "$ref": "#/definitions/ReportDestinationLocalSpec"
             }
           },
           "additionalProperties": false

--- a/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -172,6 +172,14 @@
           "items": {
             "type": "string"
           }
+        },
+        "reportExtraDetails": {
+          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `additionalData` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -174,7 +174,7 @@
           }
         },
         "reportExtraDetails": {
-          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `additionalData` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
+          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `reportExtraDetails` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
           "default": {},
           "type": "object",
           "additionalProperties": {

--- a/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -339,6 +339,20 @@
       },
       "additionalProperties": false
     },
+    "ReportDestinationLocalSpec": {
+      "description": "Create a report that is only local",
+      "type": "object",
+      "required": [
+        "directory"
+      ],
+      "properties": {
+        "directory": {
+          "description": "Directory to put the report into",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "ReportDestinationRustyPasteSpec": {
       "description": "How to upload a report to RustyPaste",
       "type": "object",
@@ -375,6 +389,18 @@
           "properties": {
             "githubIssue": {
               "$ref": "#/definitions/ReportDestinationGithubIssueSpec"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "local"
+          ],
+          "properties": {
+            "local": {
+              "$ref": "#/definitions/ReportDestinationLocalSpec"
             }
           },
           "additionalProperties": false

--- a/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -172,6 +172,14 @@
           "items": {
             "type": "string"
           }
+        },
+        "reportExtraDetails": {
+          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `additionalData` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -174,7 +174,7 @@
           }
         },
         "reportExtraDetails": {
-          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `additionalData` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
+          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `reportExtraDetails` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
           "default": {},
           "type": "object",
           "additionalProperties": {

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportDefinition.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportDefinition.json
@@ -339,6 +339,20 @@
       },
       "additionalProperties": false
     },
+    "ReportDestinationLocalSpec": {
+      "description": "Create a report that is only local",
+      "type": "object",
+      "required": [
+        "directory"
+      ],
+      "properties": {
+        "directory": {
+          "description": "Directory to put the report into",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "ReportDestinationRustyPasteSpec": {
       "description": "How to upload a report to RustyPaste",
       "type": "object",
@@ -375,6 +389,18 @@
           "properties": {
             "githubIssue": {
               "$ref": "#/definitions/ReportDestinationGithubIssueSpec"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "local"
+          ],
+          "properties": {
+            "local": {
+              "$ref": "#/definitions/ReportDestinationLocalSpec"
             }
           },
           "additionalProperties": false

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportDefinition.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportDefinition.json
@@ -172,6 +172,14 @@
           "items": {
             "type": "string"
           }
+        },
+        "reportExtraDetails": {
+          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `additionalData` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportDefinition.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportDefinition.json
@@ -174,7 +174,7 @@
           }
         },
         "reportExtraDetails": {
-          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `additionalData` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
+          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `reportExtraDetails` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
           "default": {},
           "type": "object",
           "additionalProperties": {

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -339,6 +339,20 @@
       },
       "additionalProperties": false
     },
+    "ReportDestinationLocalSpec": {
+      "description": "Create a report that is only local",
+      "type": "object",
+      "required": [
+        "directory"
+      ],
+      "properties": {
+        "directory": {
+          "description": "Directory to put the report into",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "ReportDestinationRustyPasteSpec": {
       "description": "How to upload a report to RustyPaste",
       "type": "object",
@@ -375,6 +389,18 @@
           "properties": {
             "githubIssue": {
               "$ref": "#/definitions/ReportDestinationGithubIssueSpec"
+            }
+          },
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "required": [
+            "local"
+          ],
+          "properties": {
+            "local": {
+              "$ref": "#/definitions/ReportDestinationLocalSpec"
             }
           },
           "additionalProperties": false

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -172,6 +172,14 @@
           "items": {
             "type": "string"
           }
+        },
+        "reportExtraDetails": {
+          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `additionalData` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -174,7 +174,7 @@
           }
         },
         "reportExtraDetails": {
-          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `additionalData` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
+          "description": "defines additional data that needs to be pulled from the system when reporting a bug. `reportExtraDetails` is a map of `string:string`, the value is a command that should be run. When a report is built, the commands will be run and automatically included in the report.",
           "default": {},
           "type": "object",
           "additionalProperties": {

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -95,21 +95,14 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
                 );
 
                 if let Some(rd) = &found_config.report_definition {
-                    let mut additional_report_data = BTreeMap::new();
-                    for (name, command) in &rd.additional_data {
-                        let output = transform
-                            .exec_runner
-                            .run_for_output(
-                                &found_config.bin_path,
-                                &found_config.working_dir,
-                                command,
-                            )
-                            .await;
-                        additional_report_data.insert(name.to_string(), output);
-                    }
-                    if !additional_report_data.is_empty() {
-                        builder.add_additional_data(additional_report_data).ok();
-                    }
+                    builder
+                        .run_and_capture_additional_data(
+                            &rd.additional_data,
+                            found_config,
+                            transform.exec_runner.clone(),
+                        )
+                        .await
+                        .ok();
                 }
 
                 for group_report in &result.group_reports {

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -1,6 +1,6 @@
 use super::check::{ActionRunResult, ActionRunStatus, DoctorActionRun};
 use crate::prelude::{
-    progress_bar_without_pos, CaptureOpts, ExecutionProvider, GroupReport, OutputDestination,
+    progress_bar_without_pos, ExecutionProvider, GroupReport,
 };
 use crate::report_stdout;
 use crate::shared::prelude::DoctorGroup;
@@ -94,24 +94,10 @@ where
     T: DoctorActionRun,
 {
     pub async fn execute_command(&self, command: &str) -> Result<String> {
-        let args: Vec<String> = command.split(' ').map(|x| x.to_string()).collect();
-        let result = self
+        Ok(self
             .exec_provider
-            .run_command(CaptureOpts {
-                working_dir: &self.exec_working_dir,
-                args: &args,
-                output_dest: OutputDestination::Null,
-                path: &self.sys_path,
-                env_vars: Default::default(),
-            })
-            .await;
-
-        let body = match result {
-            Ok(capture) => capture.generate_user_output(),
-            Err(error) => error.to_string(),
-        };
-
-        Ok(body)
+            .run_for_output(&self.sys_path, &self.exec_working_dir, command)
+            .await)
     }
 }
 

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -1,7 +1,5 @@
 use super::check::{ActionRunResult, ActionRunStatus, DoctorActionRun};
-use crate::prelude::{
-    progress_bar_without_pos, ExecutionProvider, GroupReport,
-};
+use crate::prelude::{progress_bar_without_pos, ExecutionProvider, GroupReport};
 use crate::report_stdout;
 use crate::shared::prelude::DoctorGroup;
 use anyhow::Result;

--- a/scope/src/doctor/tests.rs
+++ b/scope/src/doctor/tests.rs
@@ -26,7 +26,8 @@ where
         .actions(actions)
         .metadata(metadata)
         .requires(Vec::new())
-        .run_by_default(true);
+        .run_by_default(true)
+        .extra_report_args(BTreeMap::new());
 
     edit_group(group_builder).build().unwrap()
 }

--- a/scope/src/models/v1alpha/doctor_group.rs
+++ b/scope/src/models/v1alpha/doctor_group.rs
@@ -99,7 +99,7 @@ pub struct DoctorGroupSpec {
     pub include: DoctorInclude,
 
     /// defines additional data that needs to be pulled from the system when reporting a bug.
-    /// `additionalData` is a map of `string:string`, the value is a command that should be run.
+    /// `reportExtraDetails` is a map of `string:string`, the value is a command that should be run.
     /// When a report is built, the commands will be run and automatically included in the report.
     #[serde(default)]
     pub report_extra_details: BTreeMap<String, String>,

--- a/scope/src/models/v1alpha/doctor_group.rs
+++ b/scope/src/models/v1alpha/doctor_group.rs
@@ -1,6 +1,7 @@
 use derive_builder::Builder;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 use crate::models::core::ModelMetadata;
 use crate::models::v1alpha::V1AlphaApiVersion;
@@ -96,6 +97,12 @@ pub struct DoctorGroupSpec {
     /// dependency.
     #[serde(default)]
     pub include: DoctorInclude,
+
+    /// defines additional data that needs to be pulled from the system when reporting a bug.
+    /// `additionalData` is a map of `string:string`, the value is a command that should be run.
+    /// When a report is built, the commands will be run and automatically included in the report.
+    #[serde(default)]
+    pub report_extra_details: BTreeMap<String, String>,
 }
 
 /// Configure how a groups will be used when determining the task graph.

--- a/scope/src/models/v1alpha/report_location.rs
+++ b/scope/src/models/v1alpha/report_location.rs
@@ -30,12 +30,22 @@ pub struct ReportDestinationRustyPasteSpec {
     pub url: String,
 }
 
+/// Create a report that is only local
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+pub struct ReportDestinationLocalSpec {
+    /// Directory to put the report into
+    pub directory: String,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 #[schemars(deny_unknown_fields)]
 pub enum ReportDestinationSpec {
     RustyPaste(ReportDestinationRustyPasteSpec),
     GithubIssue(ReportDestinationGithubIssueSpec),
+    Local(ReportDestinationLocalSpec),
 }
 
 /// Define where to upload the report to

--- a/scope/src/shared/capture.rs
+++ b/scope/src/shared/capture.rs
@@ -42,9 +42,9 @@ pub struct OutputCapture {
     #[builder(default)]
     pub exit_code: Option<i32>,
     #[builder(default)]
-    start_time: DateTime<Utc>,
+    pub start_time: DateTime<Utc>,
     #[builder(default)]
-    end_time: DateTime<Utc>,
+    pub end_time: DateTime<Utc>,
     #[builder(default)]
     pub command: String,
 }

--- a/scope/src/shared/capture.rs
+++ b/scope/src/shared/capture.rs
@@ -128,20 +128,18 @@ pub trait ExecutionProvider: Send + Sync {
         let args: Vec<String> = command.split(' ').map(|x| x.to_string()).collect();
         let result = self
             .run_command(CaptureOpts {
-                working_dir: &workdir,
+                working_dir: workdir,
                 args: &args,
                 output_dest: OutputDestination::Null,
-                path: &path,
+                path,
                 env_vars: Default::default(),
             })
             .await;
 
-        let body = match result {
+        match result {
             Ok(capture) => capture.generate_user_output(),
             Err(error) => error.to_string(),
-        };
-
-        body
+        }
     }
 }
 

--- a/scope/src/shared/mod.rs
+++ b/scope/src/shared/mod.rs
@@ -27,7 +27,7 @@ pub mod prelude {
     pub use super::print_details;
     pub use super::report::{
         ActionReport, ActionReportBuilder, ActionTaskReport, ActionTaskReportBuilder,
-        DefaultTemplatedReportBuilder, GroupReport, ReportBuilder, TemplatedReportBuilder,
+        DefaultTemplatedReportBuilder, GroupReport, TemplatedReportBuilder,
     };
     pub use super::{CONFIG_FILE_PATH_ENV, RUN_ID_ENV_VAR};
 }

--- a/scope/src/shared/mod.rs
+++ b/scope/src/shared/mod.rs
@@ -25,7 +25,10 @@ pub mod prelude {
     pub use super::logging::{progress_bar_without_pos, LoggingOpts, STDERR_WRITER, STDOUT_WRITER};
     pub use super::models::prelude::*;
     pub use super::print_details;
-    pub use super::report::ReportBuilder;
+    pub use super::report::{
+        ActionReport, ActionReportBuilder, ActionTaskReport, ActionTaskReportBuilder,
+        DefaultTemplatedReportBuilder, GroupReport, ReportBuilder, TemplatedReportBuilder,
+    };
     pub use super::{CONFIG_FILE_PATH_ENV, RUN_ID_ENV_VAR};
 }
 

--- a/scope/src/shared/models/internal/doctor_group.rs
+++ b/scope/src/shared/models/internal/doctor_group.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::Result;
@@ -122,6 +123,7 @@ pub struct DoctorGroup {
     pub requires: Vec<String>,
     pub run_by_default: bool,
     pub actions: Vec<DoctorGroupAction>,
+    pub extra_report_args: BTreeMap<String, String>,
 }
 
 impl HelpMetadata for DoctorGroup {
@@ -158,6 +160,7 @@ impl TryFrom<V1AlphaDoctorGroup> for DoctorGroup {
             actions,
             requires: model.spec.needs,
             run_by_default: model.spec.include == DoctorInclude::ByDefault,
+            extra_report_args: model.spec.report_extra_details,
         })
     }
 }

--- a/scope/src/shared/models/internal/upload_location.rs
+++ b/scope/src/shared/models/internal/upload_location.rs
@@ -1,5 +1,6 @@
 use crate::models::prelude::{ModelMetadata, V1AlphaReportLocation};
 use crate::models::HelpMetadata;
+use crate::prelude::ReportDestinationSpec;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum ReportUploadLocationDestination {
@@ -10,6 +11,9 @@ pub enum ReportUploadLocationDestination {
         owner: String,
         repo: String,
         tags: Vec<String>,
+    },
+    Local {
+        destination: String,
     },
 }
 #[derive(Debug, PartialEq, Clone)]
@@ -34,18 +38,21 @@ impl TryFrom<V1AlphaReportLocation> for ReportUploadLocation {
 
     fn try_from(value: V1AlphaReportLocation) -> Result<Self, Self::Error> {
         let destination = match value.spec.destination {
-            crate::models::prelude::ReportDestinationSpec::RustyPaste(ref def) => {
+            ReportDestinationSpec::RustyPaste(ref def) => {
                 ReportUploadLocationDestination::RustyPaste {
                     url: def.url.to_string(),
                 }
             }
-            crate::models::prelude::ReportDestinationSpec::GithubIssue(ref github_issue) => {
+            ReportDestinationSpec::GithubIssue(ref github_issue) => {
                 ReportUploadLocationDestination::GithubIssue {
                     owner: github_issue.owner.to_string(),
                     repo: github_issue.repo.to_string(),
                     tags: github_issue.tags.clone(),
                 }
             }
+            ReportDestinationSpec::Local(ref loc) => ReportUploadLocationDestination::Local {
+                destination: loc.directory.clone(),
+            },
         };
         Ok(ReportUploadLocation {
             full_name: value.full_name(),

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -150,6 +150,17 @@ impl ReportUploadLocationDestination {
                 )
                 .await
             }
+            ReportUploadLocationDestination::Local { destination } => {
+                let id = nanoid::nanoid!(10, &nanoid::alphabet::SAFE);
+
+                let file_path = format!("{}/scope-{}.md", destination, id);
+                let mut file = File::create(&file_path)?;
+                file.write_all(report.as_bytes())?;
+
+                info!(target: "always", "Report was created at {}.", file_path);
+
+                Ok(())
+            }
         }
     }
 

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -338,6 +338,7 @@ impl ActionTaskReport {
         writeln!(f, "{}", self.get_output().trim())?;
         writeln!(f, "```\n",)?;
 
+        writeln!(f, "|Name|Value|")?;
         writeln!(f, "|:---|:---|")?;
         writeln!(f, "| Exit code| `{}` |", self.exit_code.unwrap_or(-1))?;
         writeln!(f, "| Started at| `{}` |", self.start_time)?;

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -1,8 +1,7 @@
-use super::capture::{CaptureError, CaptureOpts, OutputCapture};
+use super::capture::OutputCapture;
 use super::config_load::FoundConfig;
 use super::models::prelude::ReportUploadLocationDestination;
-use super::prelude::OutputDestination;
-use crate::prelude::ReportUploadLocation;
+use crate::prelude::{ExecutionProvider, ReportDefinition, ReportUploadLocation};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -19,123 +18,10 @@ use std::fs;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use tracing::{debug, info, warn};
 use url::Url;
-
-#[derive(Clone, Debug)]
-pub struct ReportBuilder {
-    title: String,
-    message: Option<String>,
-    command_results: String,
-}
-
-impl<'a> ReportBuilder {
-    pub async fn new_from_error(
-        title: String,
-        capture: &OutputCapture,
-        config: &'a FoundConfig,
-    ) -> Result<Self> {
-        let message = Self::make_default_message(&capture.command, config)?;
-
-        let mut this = Self {
-            title,
-            message: Some(message),
-            command_results: String::new(),
-        };
-
-        this.add_capture(capture)?;
-
-        this.add_additional_data(config).await?;
-
-        Ok(this)
-    }
-
-    pub fn new_blank(title: String) -> Self {
-        Self {
-            title,
-            message: None,
-            command_results: String::new(),
-        }
-    }
-
-    pub fn add_capture(&mut self, capture: &OutputCapture) -> Result<()> {
-        self.command_results.push('\n');
-        self.command_results
-            .push_str(&capture.create_report_text()?);
-
-        Ok(())
-    }
-
-    pub fn add_capture_error(&mut self, error: &CaptureError, command: &String) -> Result<()> {
-        self.command_results.push('\n');
-        self.command_results
-            .push_str(&error.create_report_text(command)?);
-
-        Ok(())
-    }
-
-    pub async fn add_additional_data(&mut self, config: &'a FoundConfig) -> Result<()> {
-        for command in config.get_report_definition().additional_data.values() {
-            let args: Vec<String> = command.split(' ').map(|x| x.to_string()).collect();
-            let result = OutputCapture::capture_output(CaptureOpts {
-                working_dir: &config.working_dir,
-                args: &args,
-                output_dest: OutputDestination::Null,
-                path: &config.bin_path,
-                env_vars: Default::default(),
-            })
-            .await;
-
-            match result {
-                Ok(capture) => self.add_capture(&capture)?,
-                Err(error) => self.add_capture_error(&error, command)?,
-            }
-        }
-
-        Ok(())
-    }
-
-    pub fn write_local_report(&self) -> Result<()> {
-        let report = self.make_report_test();
-
-        let base_report_loc = write_to_report_file("base", &report)?;
-        info!(target: "always", "The basic report was created at {}", base_report_loc);
-
-        Ok(())
-    }
-
-    fn make_default_message(command: &str, config: &FoundConfig) -> Result<String> {
-        let mut env = Environment::new();
-        let report_def = config.get_report_definition();
-        env.add_template("tmpl", &report_def.template)?;
-        let template = env.get_template("tmpl")?;
-        let template = template.render(context! { command => command })?;
-
-        Ok(template)
-    }
-
-    fn make_report_test(&self) -> String {
-        let top = self
-            .message
-            .clone()
-            .map_or("".to_string(), |m| format!("{}\n\n", m));
-
-        format!("{}## Captured Data\n{}", top, self.command_results)
-    }
-
-    pub async fn distribute_report(&self, config: &'a FoundConfig) -> Result<()> {
-        let report = self.make_report_test();
-
-        for dest in config.report_upload.values() {
-            if let Err(e) = &dest.destination.upload(&self.title, &report).await {
-                warn!(target: "user", "Unable to upload to {}: {}", dest.metadata.name(), e);
-            }
-        }
-
-        Ok(())
-    }
-}
 
 impl ReportUploadLocationDestination {
     async fn upload(&self, title: &str, report: &str) -> Result<()> {
@@ -280,16 +166,6 @@ async fn get_octocrab(repo: &str) -> Result<Octocrab> {
     }
 }
 
-pub fn write_to_report_file(prefix: &str, text: &str) -> Result<String> {
-    let id = nanoid::nanoid!(10, &nanoid::alphabet::SAFE);
-
-    let file_path = format!("/tmp/scope/scope-{}-{}.md", prefix, id);
-    let mut file = File::create(&file_path)?;
-    file.write_all(text.as_bytes())?;
-
-    Ok(file_path)
-}
-
 #[derive(Debug, Clone, Default, Builder)]
 #[builder(setter(into))]
 pub struct ActionTaskReport {
@@ -393,6 +269,15 @@ pub trait TemplatedReportBuilder {
 
     fn add_additional_data(&mut self, commands: BTreeMap<String, String>) -> Result<()>;
 
+    async fn run_and_capture_additional_data(
+        &mut self,
+        commands: &BTreeMap<String, String>,
+        found_config: &FoundConfig,
+        exec_provider: Arc<dyn ExecutionProvider>,
+    ) -> Result<()>;
+
+    fn append(&mut self, body: &str) -> Result<()>;
+
     async fn distribute_report(&self) -> Result<()>;
 }
 
@@ -411,6 +296,29 @@ impl DefaultTemplatedReportBuilder {
             destination: dest.clone(),
         }
     }
+
+    pub fn from_capture(
+        title: &str,
+        capture: &OutputCapture,
+        report_template: &ReportDefinition,
+        dest: &ReportUploadLocation,
+    ) -> Result<Self> {
+        let message = render_template(&capture.command, &report_template.template)?;
+        let mut this = Self::new(title, dest);
+        this.append(&message)?;
+        this.append(&capture.create_report_text()?)?;
+
+        Ok(this)
+    }
+}
+
+fn render_template(command: &str, template: &str) -> Result<String> {
+    let mut env = Environment::new();
+    env.add_template("tmpl", template)?;
+    let template = env.get_template("tmpl")?;
+    let template = template.render(context! { command => command })?;
+
+    Ok(template)
 }
 
 #[async_trait]
@@ -449,6 +357,34 @@ impl TemplatedReportBuilder for DefaultTemplatedReportBuilder {
         for (name, result) in additional_data {
             writeln!(self.output, "|{}|<pre>{}</pre>|", name, result)?;
         }
+
+        Ok(())
+    }
+
+    async fn run_and_capture_additional_data(
+        &mut self,
+        commands: &BTreeMap<String, String>,
+        found_config: &FoundConfig,
+        exec_provider: Arc<dyn ExecutionProvider>,
+    ) -> Result<()> {
+        let mut additional_report_data = BTreeMap::new();
+        for (name, command) in commands {
+            let output = exec_provider
+                .run_for_output(&found_config.bin_path, &found_config.working_dir, command)
+                .await;
+            additional_report_data.insert(name.to_string(), output);
+        }
+        if !additional_report_data.is_empty() {
+            self.add_additional_data(additional_report_data)?;
+        }
+
+        Ok(())
+    }
+
+    fn append(&mut self, body: &str) -> Result<()> {
+        use std::fmt::Write;
+
+        writeln!(self.output, "{}", body)?;
 
         Ok(())
     }


### PR DESCRIPTION
With this change, a group is now able to provide a new field
`reportExtraDetails`, that contains a map of `string:string`, this map
will run _after_ the group has executed regardless if it succeeded or
failed.

The output will be placed into a table in the markdown report.

This allows groups to add metadata about their targets to reports, making
the reports more useful.

This change includes some refactoring work (mainly around naming) that
will come in a later PR. There is also some refactoring to be done around
de-duplicating data, but wanted to exclude that for now as this PR is
already large.