### PR TITLE
[WIP] Allow report templates to be configured

### DIFF
--- a/scope/src/bin/scope-intercept.rs
+++ b/scope/src/bin/scope-intercept.rs
@@ -112,13 +112,13 @@ async fn run_command(opts: Cli) -> anyhow::Result<i32> {
         .prompt();
 
     if let Ok(true) = ans {
-        let title = format!("Scope bug report: `{:?}`", command);
+        let entrypoint = format!("{:?}", command.join(" "));
         let exec_runner = Arc::new(DefaultExecutionProvider::default());
         let report_definition = found_config.get_report_definition();
 
         for location in found_config.report_upload.values() {
             let mut builder = DefaultTemplatedReportBuilder::from_capture(
-                &title,
+                &entrypoint,
                 &capture,
                 &report_definition,
                 location,

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -90,7 +90,7 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
         if create_report {
             for location in found_config.report_upload.values() {
                 let mut builder = DefaultTemplatedReportBuilder::new(
-                    "Scope bug report: `scope doctor run`",
+                    "scope doctor run",
                     location,
                 );
 

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -542,7 +542,7 @@ mod tests {
     fn make_action_run(result: ActionRunStatus) -> Vec<MockDoctorActionRun> {
         let mut run = MockDoctorActionRun::new();
         run.expect_run_action()
-            .returning(move || Ok(ActionRunResult::from_status("a_name", result.clone())));
+            .returning(move || Ok(ActionRunResult::new("a_name", result.clone(), None, None, None)));
         run.expect_help_text().return_const(None);
         run.expect_help_url().return_const(None);
         run.expect_name().returning(|| "step name".to_string());

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -167,6 +167,7 @@ where
         group_span: &Span,
         container: &GroupActionContainer<T>,
     ) -> Result<GroupExecutionResult> {
+        println!("execute_group for {}", &container.group_name);
         let mut results = GroupExecutionResult {
             group_name: container.group_name.to_string(),
             has_failure: false,
@@ -175,6 +176,7 @@ where
         };
 
         for action in &container.actions {
+            println!("starting action {}", &action.name());
             group_span.pb_inc(1);
             if results.skip_remaining {
                 info!(target: "user", "Check `{}/{}` was skipped.", container.group_name.bold(), action.name());
@@ -189,6 +191,8 @@ where
             ));
             action_span.pb_set_style(&progress_bar_without_pos());
 
+            println!("here");
+
             let action_result = action.run_action().instrument(action_span).await?;
 
             results
@@ -199,6 +203,8 @@ where
             report_action_output(&container.group_name, action, &action_result)
                 .await
                 .ok();
+
+            println!("action_report for {}: {:?}", &action.name(), &action_result.action_report);
 
             match action_result.status {
                 ActionRunStatus::CheckSucceeded

--- a/scope/src/report/cli.rs
+++ b/scope/src/report/cli.rs
@@ -30,13 +30,13 @@ pub async fn report_root(found_config: &FoundConfig, args: &ReportArgs) -> Resul
     .await?;
     let exit_code = capture.exit_code.unwrap_or(-1);
 
-    let title = format!("Scope bug report: `{:?}`", args.command);
+    let entrypoint = format!("{:?}", args.command.join(" "));
     let exec_runner = Arc::new(DefaultExecutionProvider::default());
     let report_definition = found_config.get_report_definition();
 
     for location in found_config.report_upload.values() {
         let mut builder = DefaultTemplatedReportBuilder::from_capture(
-            &title,
+            &entrypoint,
             &capture,
             &report_definition,
             location,

--- a/scope/src/shared/body_template.jinja
+++ b/scope/src/shared/body_template.jinja
@@ -1,0 +1,85 @@
+{%- if message -%}
+{{message}}
+{%- endif %}
+
+{%- if additionalData -%}
+**Additional Capture Data**
+
+| Name | Value |
+|---|---|
+{%- for data in additionalData %}
+{{ data[0] }}|<pre>{{ data[1] }}</pre>|
+{%- endfor %}
+{%- endif %}
+
+{% for group in groups -%}
+## Group {{ group.name }}
+
+{%- for action in group.actions %}
+### Action {{group.name}}/{{action.name}}
+
+{%- for check in action.check %}
+---
+Check Command: `{{ check.command }}`
+
+{%- if check.output %}
+Output
+`text
+{{ check.output }}
+`
+{%- endif %}
+
+|Name|Value|
+|:---|:---|
+| Exit code| `{{ check.exitCode }}` |
+| Started at| `{{ check.startTime }}` |
+| Finished at| `{{ check.endTime }}` |
+{% endfor %}
+
+{%- for fix in action.fix %}
+---
+Fix Command: `{{ fix.command }}`
+
+{%- if fix.output %}
+Output
+`text
+{{ fix.output }}
+`
+{%- endif %}
+
+|Name|Value|
+|:---|:---|
+| Exit code| `{{ fix.exitCode }}` |
+| Started at| `{{ fix.startTime }}` |
+| Finished at| `{{ fix.endTime }}` |
+{% endfor %}
+
+{%- for verify in action.verify %}
+---
+Verify Command: `{{ verify.command }}`
+
+{%- if verify.output %}
+Output
+`text
+{{ verify.output }}
+`
+{%- endif %}
+
+|Name|Value|
+|:---|:---|
+| Exit code| `{{ verify.exitCode }}` |
+| Started at| `{{ verify.startTime }}` |
+| Finished at| `{{ verify.endTime }}` |
+{% endfor %}
+
+{%- if group.additionalData %}
+**Additional Capture Data**
+
+| Name | Value |
+|---|---|
+{%- for key,value in group.additionalData.items() %}
+{{ key }}|<pre>{{ value }}</pre>|
+{%- endfor %}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}


### PR DESCRIPTION
Here's my work so far in allowing reports to have configurable content. It's mainly just refactoring existing behavior so far.

My plan is to:
- refactor the existing ReportBuilder to not to any rendering i.e. it only collects output objects. Ultimately I want to delete the `DefaultTemplatedReportBuilder::output` field entirely.
- move the rendering (i.e. from Builder instance to title/body strings) into `distribute_report`. The body template probably doesn't need to be configurable.
- at this point, allowing configurable templates should be easy, as rendering will have access to the location at render time.

Misc:
- "entrypoint" is the main command the report describes the failure for. There are many commands in this context, and this one is special.