### PR TITLE
Fix report output collection during checking

### DIFF
--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -164,7 +164,7 @@ impl DoctorActionRun for DefaultDoctorActionRun {
                 ActionRunStatus::CheckSucceeded,
                 check_results.output,
                 None,
-                None
+                None,
             ));
         }
 
@@ -174,7 +174,7 @@ impl DoctorActionRun for DefaultDoctorActionRun {
                 ActionRunStatus::CheckFailedNoRunFix,
                 check_results.output,
                 None,
-                None
+                None,
             ));
         }
 
@@ -187,7 +187,7 @@ impl DoctorActionRun for DefaultDoctorActionRun {
                     ActionRunStatus::CheckFailedNoFixProvided,
                     check_results.output,
                     None,
-                    None
+                    None,
                 ));
             }
             0 => {}
@@ -218,7 +218,7 @@ impl DoctorActionRun for DefaultDoctorActionRun {
                 ActionRunStatus::NoCheckFixSucceeded,
                 check_results.output,
                 Some(fix_output),
-                None
+                None,
             ));
         }
 
@@ -348,7 +348,10 @@ impl DefaultDoctorActionRun {
         if let Some(cache_path) = &self.action.check.files {
             let result = self.evaluate_path_check(cache_path).await?;
             if !result.is_success() {
-                return Ok( CacheResults { status: result, output: None } );
+                return Ok(CacheResults {
+                    status: result,
+                    output: None,
+                });
             }
 
             path_check = Some(result);
@@ -365,13 +368,15 @@ impl DefaultDoctorActionRun {
             (None, None) => CacheStatus::CacheNotDefined,
             (Some(p), None) if p.is_success() => CacheStatus::FixNotRequired,
             (None, Some(c)) if c.status.is_success() => CacheStatus::FixNotRequired,
-            (Some(p), Some(c)) if p.is_success() && c.status.is_success() => CacheStatus::FixNotRequired,
+            (Some(p), Some(c)) if p.is_success() && c.status.is_success() => {
+                CacheStatus::FixNotRequired
+            }
             _ => CacheStatus::FixRequired,
         };
 
         let output = match command_check {
             Some(c) => c.output.clone(),
-            None => None
+            None => None,
         };
 
         Ok(CacheResults { status, output })

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -60,15 +60,6 @@ pub struct CacheResults {
     pub output: Option<Vec<ActionTaskReport>>,
 }
 
-impl From<CacheStatus> for CacheResults {
-    fn from(value: CacheStatus) -> Self {
-        Self {
-            status: value,
-            output: None,
-        }
-    }
-}
-
 #[derive(Debug, PartialEq, Clone)]
 #[allow(clippy::enum_variant_names)]
 pub enum ActionRunStatus {
@@ -117,10 +108,6 @@ impl ActionRunResult {
                 .build()
                 .expect("report builder to have all values set"),
         }
-    }
-
-    pub fn from_status(name: &str, status: ActionRunStatus) -> Self {
-        Self::new(name, status, None, None, None)
     }
 }
 
@@ -172,18 +159,36 @@ impl DoctorActionRun for DefaultDoctorActionRun {
         let check_results = self.evaluate_checks().await?;
         let check_status = check_results.status;
         if check_status == CacheStatus::FixNotRequired {
-            return Ok(self.result_without_output(ActionRunStatus::CheckSucceeded));
+            return Ok(ActionRunResult::new(
+                &self.name(),
+                ActionRunStatus::CheckSucceeded,
+                check_results.output,
+                None,
+                None
+            ));
         }
 
         if !self.run_fix {
-            return Ok(self.result_without_output(ActionRunStatus::CheckFailedNoRunFix));
+            return Ok(ActionRunResult::new(
+                &self.name(),
+                ActionRunStatus::CheckFailedNoRunFix,
+                check_results.output,
+                None,
+                None
+            ));
         }
 
         let (fix_result, fix_output) = self.run_fixes().await?;
 
         match fix_result {
             i32::MIN..=-1 => {
-                return Ok(self.result_without_output(ActionRunStatus::CheckFailedNoFixProvided));
+                return Ok(ActionRunResult::new(
+                    &self.name(),
+                    ActionRunStatus::CheckFailedNoFixProvided,
+                    check_results.output,
+                    None,
+                    None
+                ));
             }
             0 => {}
             1...100 => {
@@ -208,24 +213,38 @@ impl DoctorActionRun for DefaultDoctorActionRun {
 
         if check_status == CacheStatus::CacheNotDefined {
             self.update_caches().await;
-            return Ok(self.result_without_output(ActionRunStatus::NoCheckFixSucceeded));
+            return Ok(ActionRunResult::new(
+                &self.name(),
+                ActionRunStatus::NoCheckFixSucceeded,
+                check_results.output,
+                Some(fix_output),
+                None
+            ));
         }
 
+        let mut validate_output = None;
         if let Some(validate_result) = self.evaluate_command_checks().await? {
+            validate_output = validate_result.output;
             if validate_result.status != CacheStatus::FixNotRequired {
                 return Ok(ActionRunResult::new(
                     &self.name(),
                     ActionRunStatus::CheckFailedFixSucceedVerifyFailed,
                     check_results.output,
                     Some(fix_output),
-                    validate_result.output,
+                    validate_output,
                 ));
             }
         }
 
         self.update_caches().await;
 
-        Ok(self.result_without_output(ActionRunStatus::CheckFailedFixSucceedVerifySucceed))
+        return Ok(ActionRunResult::new(
+            &self.name(),
+            ActionRunStatus::CheckFailedFixSucceedVerifySucceed,
+            check_results.output,
+            Some(fix_output),
+            validate_output,
+        ));
     }
 
     fn required(&self) -> bool {
@@ -250,10 +269,6 @@ impl DoctorActionRun for DefaultDoctorActionRun {
 }
 
 impl DefaultDoctorActionRun {
-    fn result_without_output(&self, action_run_status: ActionRunStatus) -> ActionRunResult {
-        ActionRunResult::from_status(&self.name(), action_run_status)
-    }
-
     async fn update_caches(&self) {
         if let Some(cache_path) = &self.action.check.files {
             let result = self
@@ -333,7 +348,7 @@ impl DefaultDoctorActionRun {
         if let Some(cache_path) = &self.action.check.files {
             let result = self.evaluate_path_check(cache_path).await?;
             if !result.is_success() {
-                return Ok(result.into());
+                return Ok( CacheResults { status: result, output: None } );
             }
 
             path_check = Some(result);
@@ -346,15 +361,20 @@ impl DefaultDoctorActionRun {
             command_check = Some(results);
         }
 
-        match (path_check, command_check) {
-            (None, None) => Ok(CacheStatus::CacheNotDefined.into()),
-            (Some(p), None) if p.is_success() => Ok(CacheStatus::FixNotRequired.into()),
-            (None, Some(c)) if c.status.is_success() => Ok(CacheStatus::FixNotRequired.into()),
-            (Some(p), Some(c)) if p.is_success() && c.status.is_success() => {
-                Ok(CacheStatus::FixNotRequired.into())
-            }
-            _ => Ok(CacheStatus::FixRequired.into()),
-        }
+        let status = match (&path_check, &command_check) {
+            (None, None) => CacheStatus::CacheNotDefined,
+            (Some(p), None) if p.is_success() => CacheStatus::FixNotRequired,
+            (None, Some(c)) if c.status.is_success() => CacheStatus::FixNotRequired,
+            (Some(p), Some(c)) if p.is_success() && c.status.is_success() => CacheStatus::FixNotRequired,
+            _ => CacheStatus::FixRequired,
+        };
+
+        let output = match command_check {
+            Some(c) => c.output.clone(),
+            None => None
+        };
+
+        Ok(CacheResults { status, output })
     }
 
     async fn evaluate_command_checks(&self) -> Result<Option<CacheResults>, RuntimeError> {

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -682,6 +682,7 @@ pub(crate) mod tests {
 
         let result = run.run_action().await?;
         assert_eq!(ActionRunStatus::CheckSucceeded, result.status);
+        assert!(result.action_report.check.len() == 1);
 
         Ok(())
     }
@@ -703,6 +704,10 @@ pub(crate) mod tests {
             result.status
         );
 
+        assert!(result.action_report.check.len() == 1);
+        assert!(result.action_report.fix.len() == 1);
+        assert!(result.action_report.validate.len() == 1);
+
         Ok(())
     }
 
@@ -723,6 +728,10 @@ pub(crate) mod tests {
             result.status
         );
 
+        assert!(result.action_report.check.len() == 1);
+        assert!(result.action_report.fix.len() == 1);
+        assert!(result.action_report.validate.len() == 1);
+
         Ok(())
     }
 
@@ -739,6 +748,9 @@ pub(crate) mod tests {
 
         let result = run.run_action().await?;
         assert_eq!(ActionRunStatus::CheckFailedFixFailed, result.status);
+
+        assert!(result.action_report.check.len() == 1);
+        assert!(result.action_report.fix.len() == 1);
 
         Ok(())
     }
@@ -768,6 +780,8 @@ pub(crate) mod tests {
             result.status
         );
 
+        assert!(result.action_report.fix.len() == 1);
+
         Ok(())
     }
 
@@ -796,6 +810,8 @@ pub(crate) mod tests {
             result.status
         );
 
+        assert!(result.action_report.fix.len() == 1);
+
         Ok(())
     }
 
@@ -817,6 +833,8 @@ pub(crate) mod tests {
 
         let result = run.run_action().await?;
         assert_eq!(ActionRunStatus::CheckFailedFixFailed, result.status);
+
+        assert!(result.action_report.fix.len() == 1);
 
         Ok(())
     }

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -535,8 +535,15 @@ mod tests {
 
     fn make_action_run(result: ActionRunStatus) -> Vec<MockDoctorActionRun> {
         let mut run = MockDoctorActionRun::new();
-        run.expect_run_action()
-            .returning(move || Ok(ActionRunResult::new("a_name", result.clone(), None, None, None)));
+        run.expect_run_action().returning(move || {
+            Ok(ActionRunResult::new(
+                "a_name",
+                result.clone(),
+                None,
+                None,
+                None,
+            ))
+        });
         run.expect_help_text().return_const(None);
         run.expect_help_url().return_const(None);
         run.expect_name().returning(|| "step name".to_string());

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -536,7 +536,7 @@ mod tests {
     fn make_action_run(result: ActionRunStatus) -> Vec<MockDoctorActionRun> {
         let mut run = MockDoctorActionRun::new();
         run.expect_run_action()
-            .returning(move || Ok(ActionRunResult::from_status("a_name", result.clone())));
+            .returning(move || Ok(ActionRunResult::new("a_name", result.clone(), None, None, None)));
         run.expect_help_text().return_const(None);
         run.expect_help_url().return_const(None);
         run.expect_name().returning(|| "step name".to_string());


### PR DESCRIPTION
From my work on https://github.com/oscope-dev/scope/pull/122, I noticed that some check/fix/validate output would be excluded from the report. This PR fixes those cases, and enhances the existing tests to catch the cases.