### PR TITLE
Use templates for report rendering

### DIFF
--- a/scope/src/bin/scope-intercept.rs
+++ b/scope/src/bin/scope-intercept.rs
@@ -128,10 +128,15 @@ async fn run_command(opts: Cli) -> anyhow::Result<i32> {
             .ok();
 
         for location in found_config.report_upload.values() {
-            let report = builder.render(location)?;
+            let report = builder.render(location);
 
-            if let Err(e) = report.distribute().await {
-                warn!(target: "user", "Unable to upload report: {}", e);
+            match report {
+                Err(e) => warn!(target: "user", "Unable to render report: {}", e),
+                Ok(report) => {
+                    if let Err(e) = report.distribute().await {
+                        warn!(target: "user", "Unable to upload report: {}", e);
+                    }
+                }
             }
         }
     }

--- a/scope/src/bin/scope-intercept.rs
+++ b/scope/src/bin/scope-intercept.rs
@@ -116,11 +116,19 @@ async fn run_command(opts: Cli) -> anyhow::Result<i32> {
         let exec_runner = Arc::new(DefaultExecutionProvider::default());
         let report_definition = found_config.get_report_definition();
 
-        let mut builder = DefaultUnstructuredReportBuilder::new(&report_definition, &entrypoint, &capture);
-        builder.run_and_append_additional_data(&found_config, exec_runner, &report_definition.additional_data).await.ok();
+        let mut builder =
+            DefaultUnstructuredReportBuilder::new(&report_definition, &entrypoint, &capture);
+        builder
+            .run_and_append_additional_data(
+                &found_config,
+                exec_runner,
+                &report_definition.additional_data,
+            )
+            .await
+            .ok();
 
         for location in found_config.report_upload.values() {
-            let report = builder.render(&location)?;
+            let report = builder.render(location)?;
 
             if let Err(e) = report.distribute().await {
                 warn!(target: "user", "Unable to upload report: {}", e);

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -111,10 +111,15 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
             }
 
             for location in found_config.report_upload.values() {
-                let report = builder.render(location)?;
+                let report = builder.render(location);
 
-                if let Err(e) = report.distribute().await {
-                    warn!(target: "user", "Unable to upload report: {}", e);
+                match report {
+                    Err(e) => warn!(target: "user", "Unable to render report: {}", e),
+                    Ok(report) => {
+                        if let Err(e) = report.distribute().await {
+                            warn!(target: "user", "Unable to upload report: {}", e);
+                        }
+                    }
                 }
             }
         }

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -9,7 +9,9 @@ use tracing::{info, instrument, warn};
 use crate::doctor::check::{DefaultDoctorActionRun, DefaultGlobWalker};
 use crate::doctor::file_cache::{FileBasedCache, FileCache, NoOpCache};
 use crate::doctor::runner::{compute_group_order, GroupActionContainer, RunGroups};
-use crate::prelude::{DefaultGroupedReportBuilder, ExecutionProvider, GroupedReportBuilder, ReportRenderer};
+use crate::prelude::{
+    DefaultGroupedReportBuilder, ExecutionProvider, GroupedReportBuilder, ReportRenderer,
+};
 use crate::report_stdout;
 use crate::shared::prelude::{DefaultExecutionProvider, FoundConfig};
 
@@ -90,7 +92,7 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
         if create_report {
             let mut builder = DefaultGroupedReportBuilder::new(
                 &found_config.report_definition,
-                "scope doctor run"
+                "scope doctor run",
             );
 
             if let Some(rd) = &found_config.report_definition {
@@ -109,7 +111,7 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
             }
 
             for location in found_config.report_upload.values() {
-                let report = builder.render(&location)?;
+                let report = builder.render(location)?;
 
                 if let Err(e) = report.distribute().await {
                     warn!(target: "user", "Unable to upload report: {}", e);

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -221,6 +221,7 @@ where
             let output = container.execute_command(command).await.ok();
             results.group_report.add_additional_details(
                 name,
+                command,
                 &output.unwrap_or_else(|| "Unable to capture output".to_string()),
             );
         }

--- a/scope/src/report/cli.rs
+++ b/scope/src/report/cli.rs
@@ -47,10 +47,15 @@ pub async fn report_root(found_config: &FoundConfig, args: &ReportArgs) -> Resul
         .ok();
 
     for location in found_config.report_upload.values() {
-        let report = builder.render(location)?;
+        let report = builder.render(location);
 
-        if let Err(e) = report.distribute().await {
-            warn!(target: "user", "Unable to upload report: {}", e);
+        match report {
+            Err(e) => warn!(target: "user", "Unable to render report: {}", e),
+            Ok(report) => {
+                if let Err(e) = report.distribute().await {
+                    warn!(target: "user", "Unable to upload report: {}", e);
+                }
+            }
         }
     }
 

--- a/scope/src/report/cli.rs
+++ b/scope/src/report/cli.rs
@@ -1,5 +1,6 @@
 use crate::prelude::{
-    DefaultExecutionProvider, DefaultUnstructuredReportBuilder, ReportRenderer, UnstructuredReportBuilder
+    DefaultExecutionProvider, DefaultUnstructuredReportBuilder, ReportRenderer,
+    UnstructuredReportBuilder,
 };
 use crate::shared::prelude::{CaptureOpts, FoundConfig, OutputCapture, OutputDestination};
 use anyhow::Result;
@@ -34,11 +35,19 @@ pub async fn report_root(found_config: &FoundConfig, args: &ReportArgs) -> Resul
     let exec_runner = Arc::new(DefaultExecutionProvider::default());
     let report_definition = found_config.get_report_definition();
 
-    let mut builder = DefaultUnstructuredReportBuilder::new(&report_definition, &entrypoint, &capture);
-    builder.run_and_append_additional_data(found_config, exec_runner, &report_definition.additional_data).await.ok();
+    let mut builder =
+        DefaultUnstructuredReportBuilder::new(&report_definition, &entrypoint, &capture);
+    builder
+        .run_and_append_additional_data(
+            found_config,
+            exec_runner,
+            &report_definition.additional_data,
+        )
+        .await
+        .ok();
 
     for location in found_config.report_upload.values() {
-        let report = builder.render(&location)?;
+        let report = builder.render(location)?;
 
         if let Err(e) = report.distribute().await {
             warn!(target: "user", "Unable to upload report: {}", e);

--- a/scope/src/report/cli.rs
+++ b/scope/src/report/cli.rs
@@ -1,5 +1,5 @@
 use crate::prelude::{
-    DefaultExecutionProvider, DefaultTemplatedReportBuilder, TemplatedReportBuilder,
+    DefaultExecutionProvider, DefaultUnstructuredReportBuilder, ReportRenderer, UnstructuredReportBuilder
 };
 use crate::shared::prelude::{CaptureOpts, FoundConfig, OutputCapture, OutputDestination};
 use anyhow::Result;
@@ -30,27 +30,17 @@ pub async fn report_root(found_config: &FoundConfig, args: &ReportArgs) -> Resul
     .await?;
     let exit_code = capture.exit_code.unwrap_or(-1);
 
-    let title = format!("Scope bug report: `{:?}`", args.command);
+    let entrypoint = args.command.join(" ");
     let exec_runner = Arc::new(DefaultExecutionProvider::default());
     let report_definition = found_config.get_report_definition();
 
-    for location in found_config.report_upload.values() {
-        let mut builder = DefaultTemplatedReportBuilder::from_capture(
-            &title,
-            &capture,
-            &report_definition,
-            location,
-        )?;
-        builder
-            .run_and_capture_additional_data(
-                &report_definition.additional_data,
-                found_config,
-                exec_runner.clone(),
-            )
-            .await
-            .ok();
+    let mut builder = DefaultUnstructuredReportBuilder::new(&report_definition, &entrypoint, &capture);
+    builder.run_and_append_additional_data(found_config, exec_runner, &report_definition.additional_data).await.ok();
 
-        if let Err(e) = builder.distribute_report().await {
+    for location in found_config.report_upload.values() {
+        let report = builder.render(&location)?;
+
+        if let Err(e) = report.distribute().await {
             warn!(target: "user", "Unable to upload report: {}", e);
         }
     }

--- a/scope/src/shared/capture.rs
+++ b/scope/src/shared/capture.rs
@@ -30,7 +30,7 @@ impl RwLockOutput {
     }
 }
 
-#[derive(Default, Builder)]
+#[derive(Clone, Default, Builder)]
 #[builder(setter(into))]
 pub struct OutputCapture {
     #[builder(default)]

--- a/scope/src/shared/capture.rs
+++ b/scope/src/shared/capture.rs
@@ -6,7 +6,6 @@ use derive_builder::Builder;
 use mockall::automock;
 use std::collections::BTreeMap;
 use std::ffi::OsString;
-use std::fmt::Write;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -104,19 +103,6 @@ pub enum CaptureError {
         #[from]
         error: std::string::FromUtf8Error,
     },
-}
-
-impl CaptureError {
-    pub fn create_report_text(&self, command: &String) -> anyhow::Result<String> {
-        let mut f = String::new();
-        writeln!(&mut f, "### `{}`", command)?;
-        writeln!(&mut f)?;
-
-        writeln!(&mut f, "```text")?;
-        writeln!(&mut f, "CaptureError: {}", self)?;
-        writeln!(&mut f, "```")?;
-        Ok(f)
-    }
 }
 
 #[automock]
@@ -272,23 +258,6 @@ impl OutputCapture {
             .map(|(_, line)| line.clone())
             .collect::<Vec<_>>()
             .join("\n")
-    }
-
-    pub fn create_report_text(&self) -> anyhow::Result<String> {
-        let mut f = String::new();
-        writeln!(&mut f, "### `{}`", self.command)?;
-        writeln!(&mut f)?;
-
-        writeln!(&mut f, "```text")?;
-        writeln!(&mut f, "{}", self.generate_output().trim())?;
-        writeln!(&mut f, "```")?;
-        writeln!(&mut f)?;
-
-        writeln!(&mut f, "- Exit code: `{}`", self.exit_code.unwrap_or(-1))?;
-        writeln!(&mut f, "- Started at: `{}`", self.start_time)?;
-        writeln!(&mut f, "- Finished at: `{}`", self.end_time)?;
-
-        Ok(f)
     }
 
     pub fn get_stdout(&self) -> String {

--- a/scope/src/shared/grouped_body.jinja
+++ b/scope/src/shared/grouped_body.jinja
@@ -23,7 +23,7 @@
 Check Command: `{{ check.command }}`
 
 {% if check.output %}
-Output
+Output:
 ```text
 {{ check.output }}
 ```
@@ -41,7 +41,7 @@ Output
 Fix Command: `{{ fix.command }}`
 
 {% if fix.output %}
-Output
+Output:
 ```text
 {{ fix.output }}
 ```
@@ -59,7 +59,7 @@ Output
 Verify Command: `{{ verify.command }}`
 
 {% if verify.output %}
-Output
+Output:
 ```text
 {{ verify.output }}
 ```

--- a/scope/src/shared/grouped_body.jinja
+++ b/scope/src/shared/grouped_body.jinja
@@ -1,0 +1,85 @@
+{%- if message -%}
+{{message}}
+{%- endif %}
+
+{%- if additionalData -%}
+**Additional Capture Data**
+
+| Name | Value |
+|---|---|
+{%- for data in additionalData %}
+{{ data[0] }}|<pre>{{ data[1] }}</pre>|
+{%- endfor %}
+{%- endif %}
+
+{% for group in groups -%}
+## Group {{ group.name }}
+
+{%- for action in group.actions %}
+### Action {{group.name}}/{{action.name}}
+
+{%- for check in action.check %}
+---
+Check Command: `{{ check.command }}`
+
+{%- if check.output %}
+Output
+`text
+{{ check.output }}
+`
+{%- endif %}
+
+|Name|Value|
+|:---|:---|
+| Exit code| `{{ check.exitCode }}` |
+| Started at| `{{ check.startTime }}` |
+| Finished at| `{{ check.endTime }}` |
+{% endfor %}
+
+{%- for fix in action.fix %}
+---
+Fix Command: `{{ fix.command }}`
+
+{%- if fix.output %}
+Output
+`text
+{{ fix.output }}
+`
+{%- endif %}
+
+|Name|Value|
+|:---|:---|
+| Exit code| `{{ fix.exitCode }}` |
+| Started at| `{{ fix.startTime }}` |
+| Finished at| `{{ fix.endTime }}` |
+{% endfor %}
+
+{%- for verify in action.verify %}
+---
+Verify Command: `{{ verify.command }}`
+
+{%- if verify.output %}
+Output
+`text
+{{ verify.output }}
+`
+{%- endif %}
+
+|Name|Value|
+|:---|:---|
+| Exit code| `{{ verify.exitCode }}` |
+| Started at| `{{ verify.startTime }}` |
+| Finished at| `{{ verify.endTime }}` |
+{% endfor %}
+
+{%- if group.additionalData %}
+**Additional Capture Data**
+
+| Name | Value |
+|---|---|
+{%- for key,value in group.additionalData.items() %}
+{{ key }}|<pre>{{ value }}</pre>|
+{%- endfor %}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}

--- a/scope/src/shared/grouped_body.jinja
+++ b/scope/src/shared/grouped_body.jinja
@@ -8,7 +8,7 @@
 | Name | Value |
 |---|---|
 {% for data in additionalData %}
-|{{ data[0] }}|`{{ data[1] }}`|
+|{{ data.name }}|`{{ data.output }}`|
 {% endfor %}
 {% endif %}
 
@@ -73,12 +73,12 @@ Output
 {% endfor %}
 
 {% if group.additionalData %}
-**Additional Capture Data**
+### Additional Capture Data
 
 | Name | Value |
 |---|---|
-{% for key,value in group.additionalData.items() %}
-|{{ key }}|`{{ value }}`|
+{% for data in group.additionalData %}
+|{{ data.name }}|`{{ data.output }}`|
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/scope/src/shared/grouped_body.jinja
+++ b/scope/src/shared/grouped_body.jinja
@@ -1,34 +1,34 @@
-{%- if message -%}
+{% if message %}
 {{message}}
-{%- endif %}
+{% endif %}
 
-{%- if additionalData -%}
+{% if additionalData %}
 **Additional Capture Data**
 
 | Name | Value |
 |---|---|
-{%- for data in additionalData %}
-{{ data[0] }}|<pre>{{ data[1] }}</pre>|
-{%- endfor %}
-{%- endif %}
+{% for data in additionalData %}
+|{{ data[0] }}|`{{ data[1] }}`|
+{% endfor %}
+{% endif %}
 
-{% for group in groups -%}
+{% for group in groups %}
 ## Group {{ group.name }}
 
-{%- for action in group.actions %}
+{% for action in group.actions %}
 ### Action {{group.name}}/{{action.name}}
 
-{%- for check in action.check %}
+{% for check in action.check %}
 ---
 Check Command: `{{ check.command }}`
 
-{%- if check.output %}
+{% if check.output %}
 Output
-`text
+```text
 {{ check.output }}
-`
-{%- endif %}
+```
 
+{% endif %}
 |Name|Value|
 |:---|:---|
 | Exit code| `{{ check.exitCode }}` |
@@ -36,17 +36,17 @@ Output
 | Finished at| `{{ check.endTime }}` |
 {% endfor %}
 
-{%- for fix in action.fix %}
+{% for fix in action.fix %}
 ---
 Fix Command: `{{ fix.command }}`
 
-{%- if fix.output %}
+{% if fix.output %}
 Output
-`text
+```text
 {{ fix.output }}
-`
-{%- endif %}
+```
 
+{% endif %}
 |Name|Value|
 |:---|:---|
 | Exit code| `{{ fix.exitCode }}` |
@@ -54,17 +54,17 @@ Output
 | Finished at| `{{ fix.endTime }}` |
 {% endfor %}
 
-{%- for verify in action.verify %}
+{% for verify in action.verify %}
 ---
 Verify Command: `{{ verify.command }}`
 
-{%- if verify.output %}
+{% if verify.output %}
 Output
-`text
+```text
 {{ verify.output }}
-`
-{%- endif %}
+```
 
+{% endif %}
 |Name|Value|
 |:---|:---|
 | Exit code| `{{ verify.exitCode }}` |
@@ -72,14 +72,14 @@ Output
 | Finished at| `{{ verify.endTime }}` |
 {% endfor %}
 
-{%- if group.additionalData %}
+{% if group.additionalData %}
 **Additional Capture Data**
 
 | Name | Value |
 |---|---|
-{%- for key,value in group.additionalData.items() %}
-{{ key }}|<pre>{{ value }}</pre>|
-{%- endfor %}
-{%- endif %}
-{%- endfor %}
-{%- endfor %}
+{% for key,value in group.additionalData.items() %}
+|{{ key }}|`{{ value }}`|
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endfor %}

--- a/scope/src/shared/grouped_body.jinja
+++ b/scope/src/shared/grouped_body.jinja
@@ -8,7 +8,7 @@
 | Name | Value |
 |---|---|
 {% for data in additionalData %}
-|{{ data.name }}|`{{ data.output }}`|
+|{{ data.name }}|{% if data.output %}`{{ data.output }}`{% endif %}|
 {% endfor %}
 {% endif %}
 
@@ -78,7 +78,7 @@ Output:
 | Name | Value |
 |---|---|
 {% for data in group.additionalData %}
-|{{ data.name }}|`{{ data.output }}`|
+|{{ data.name }}|{% if data.output %}`{{ data.output }}`{% endif %}|
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/scope/src/shared/mod.rs
+++ b/scope/src/shared/mod.rs
@@ -27,10 +27,8 @@ pub mod prelude {
     pub use super::print_details;
     pub use super::report::{
         ActionReport, ActionReportBuilder, ActionTaskReport, ActionTaskReportBuilder,
-        GroupReport,
-        DefaultGroupedReportBuilder, GroupedReportBuilder,
-        DefaultUnstructuredReportBuilder, UnstructuredReportBuilder,
-        ReportRenderer, Report,
+        DefaultGroupedReportBuilder, DefaultUnstructuredReportBuilder, GroupReport,
+        GroupedReportBuilder, Report, ReportRenderer, UnstructuredReportBuilder,
     };
     pub use super::{CONFIG_FILE_PATH_ENV, RUN_ID_ENV_VAR};
 }

--- a/scope/src/shared/mod.rs
+++ b/scope/src/shared/mod.rs
@@ -27,7 +27,10 @@ pub mod prelude {
     pub use super::print_details;
     pub use super::report::{
         ActionReport, ActionReportBuilder, ActionTaskReport, ActionTaskReportBuilder,
-        DefaultTemplatedReportBuilder, GroupReport, TemplatedReportBuilder,
+        GroupReport,
+        DefaultGroupedReportBuilder, GroupedReportBuilder,
+        DefaultUnstructuredReportBuilder, UnstructuredReportBuilder,
+        ReportRenderer, Report,
     };
     pub use super::{CONFIG_FILE_PATH_ENV, RUN_ID_ENV_VAR};
 }

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -717,7 +717,7 @@ An error occured with hello world
 ---
 Check Command: `action first`
 
-Output
+Output:
 ```text
 first line
 second line
@@ -802,7 +802,7 @@ An error occured with `hello world`.
 
 ## Command `hello world`
 
-Output
+Output:
 ```text
 stdout
 stderr

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -347,7 +347,6 @@ impl DefaultUnstructuredReportBuilder {
            // https://github.com/mitsuhiko/minijinja/issues/32
            additionalData => Vec::from_iter(self.additional_data.iter()),
         };
-        println!("{:?}", ctx);
         let rendered = template.render(ctx)?;
 
         Ok(rendered)

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -454,6 +454,8 @@ impl DefaultGroupedReportBuilder {
 
     fn render_body(&self, _destination: &ReportUploadLocation) -> Result<String> {
         let mut env = Environment::new();
+        env.set_trim_blocks(true);
+        env.set_lstrip_blocks(true);
         env.add_template("body", self.get_body_template())?;
         let template = env.get_template("body")?;
 
@@ -508,6 +510,9 @@ struct ReportCommandResultContext {
 
     #[serde(rename = "endTime")]
     end_time: String,
+
+    #[serde(rename = "output")]
+    output: String,
 }
 
 impl ReportCommandResultContext {
@@ -517,6 +522,7 @@ impl ReportCommandResultContext {
             exit_code: report.exit_code.unwrap_or(-1),
             start_time: report.start_time.to_string(),
             end_time: report.end_time.to_string(),
+            output: report.output.clone().unwrap_or("".to_string()),
         }
     }
 }

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -6,6 +6,7 @@ use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use derive_builder::Builder;
+use itertools::Itertools;
 use jsonwebtoken::EncodingKey;
 use minijinja::{context, Environment};
 use normpath::PathExt;
@@ -19,6 +20,7 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
+use serde::{Deserialize, Serialize};
 
 use tracing::{debug, info, warn};
 use url::Url;
@@ -263,142 +265,313 @@ impl GroupReport {
     }
 }
 
-#[async_trait]
-pub trait TemplatedReportBuilder {
-    fn create_group(&mut self, group_result: &GroupReport) -> Result<()>;
-
-    fn add_additional_data(&mut self, commands: BTreeMap<String, String>) -> Result<()>;
-
-    async fn run_and_capture_additional_data(
-        &mut self,
-        commands: &BTreeMap<String, String>,
-        found_config: &FoundConfig,
-        exec_provider: Arc<dyn ExecutionProvider>,
-    ) -> Result<()>;
-
-    fn append(&mut self, body: &str) -> Result<()>;
-
-    async fn distribute_report(&self) -> Result<()>;
-}
-
-#[derive(Debug, Clone)]
-pub struct DefaultTemplatedReportBuilder {
+// Shared
+pub struct Report {
     title: String,
-    output: String,
+    body: String,
     destination: ReportUploadLocation,
 }
 
-impl DefaultTemplatedReportBuilder {
-    pub fn new(title: &str, dest: &ReportUploadLocation) -> Self {
-        Self {
-            title: title.to_string(),
-            output: format!("# {}\n", title),
-            destination: dest.clone(),
-        }
-    }
-
-    pub fn from_capture(
-        title: &str,
-        capture: &OutputCapture,
-        report_template: &ReportDefinition,
-        dest: &ReportUploadLocation,
-    ) -> Result<Self> {
-        let message = render_template(&capture.command, &report_template.template)?;
-        let mut this = Self::new(title, dest);
-        this.append(&message)?;
-        this.append(&capture.create_report_text()?)?;
-
-        Ok(this)
-    }
-}
-
-fn render_template(command: &str, template: &str) -> Result<String> {
-    let mut env = Environment::new();
-    env.add_template("tmpl", template)?;
-    let template = env.get_template("tmpl")?;
-    let template = template.render(context! { command => command })?;
-
-    Ok(template)
-}
-
-#[async_trait]
-impl TemplatedReportBuilder for DefaultTemplatedReportBuilder {
-    fn create_group(&mut self, group_result: &GroupReport) -> Result<()> {
-        use std::fmt::Write;
-
-        writeln!(self.output)?;
-        writeln!(self.output, "## Group `{}`\n", group_result.group_name)?;
-        for action in &group_result.action_result {
-            writeln!(
-                self.output,
-                "### Action `{}/{}`",
-                group_result.group_name, action.action_name
-            )?;
-
-            for check in &action.check {
-                check.write_output(&mut self.output)?;
-            }
-        }
-
-        if !group_result.additional_details.is_empty() {
-            self.add_additional_data(group_result.additional_details.clone())?
-        }
-
-        Ok(())
-    }
-
-    fn add_additional_data(&mut self, additional_data: BTreeMap<String, String>) -> Result<()> {
-        use std::fmt::Write;
-
-        writeln!(self.output, "\n**Additional Capture Data**\n")?;
-        writeln!(self.output, "| Name | Value |")?;
-        writeln!(self.output, "|:---|:---|")?;
-
-        for (name, result) in additional_data {
-            writeln!(self.output, "|{}|<pre>{}</pre>|", name, result)?;
-        }
-
-        Ok(())
-    }
-
-    async fn run_and_capture_additional_data(
-        &mut self,
-        commands: &BTreeMap<String, String>,
-        found_config: &FoundConfig,
-        exec_provider: Arc<dyn ExecutionProvider>,
-    ) -> Result<()> {
-        let mut additional_report_data = BTreeMap::new();
-        for (name, command) in commands {
-            let output = exec_provider
-                .run_for_output(&found_config.bin_path, &found_config.working_dir, command)
-                .await;
-            additional_report_data.insert(name.to_string(), output);
-        }
-        if !additional_report_data.is_empty() {
-            self.add_additional_data(additional_report_data)?;
-        }
-
-        Ok(())
-    }
-
-    fn append(&mut self, body: &str) -> Result<()> {
-        use std::fmt::Write;
-
-        writeln!(self.output, "{}", body)?;
-
-        Ok(())
-    }
-
-    async fn distribute_report(&self) -> Result<()> {
+impl Report {
+    pub async fn distribute(&self) -> Result<()> {
         if let Err(e) = &self
             .destination
             .destination
-            .upload(&self.title, &self.output)
+            .upload(&self.title, &self.body)
             .await
         {
             warn!(target: "user", "Unable to upload to {}: {}", self.destination.metadata.name(), e);
         }
 
         Ok(())
+    }
+}
+
+pub trait ReportRenderer {
+    fn render(&self, destination: &ReportUploadLocation) -> Result<Report>;
+}
+
+
+// Unstructured reports
+#[async_trait]
+pub trait UnstructuredReportBuilder {
+    async fn run_and_append_additional_data(&mut self, found_config: &FoundConfig, exec_runner: Arc<dyn ExecutionProvider>, commands: &BTreeMap<String, String>) -> Result<()>;
+}
+
+pub struct DefaultUnstructuredReportBuilder {
+    entrypoint: String,
+    // TODO: accept capture output for generic report builder
+    _capture: OutputCapture,
+    additional_data: BTreeMap<String, String>,
+    message_template: String,
+}
+
+impl DefaultUnstructuredReportBuilder {
+    pub fn new(report: &ReportDefinition, entrypoint: &str, capture: &OutputCapture) -> Self {
+        Self {
+            message_template: report.template.clone(),
+            entrypoint: entrypoint.to_string(),
+            _capture: capture.clone(),
+            additional_data: BTreeMap::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl UnstructuredReportBuilder for DefaultUnstructuredReportBuilder {
+    async fn run_and_append_additional_data(&mut self, found_config: &FoundConfig, exec_provider: Arc<dyn ExecutionProvider>, commands: &BTreeMap<String, String>) -> Result<()> {
+        for (name, command) in commands {
+            let output = exec_provider
+                .run_for_output(&found_config.bin_path, &found_config.working_dir, command)
+                .await;
+            self.additional_data.insert(name.to_string(), output);
+        }
+
+        Ok(())
+    }
+}
+
+impl ReportRenderer for DefaultUnstructuredReportBuilder {
+    fn render(&self, destination: &ReportUploadLocation) -> Result<Report> {
+        let title = self.render_title(destination)?;
+        let body = self.render_body(destination)?;
+
+        Ok(Report { title, body, destination: destination.clone() })
+    }
+}
+
+impl DefaultUnstructuredReportBuilder {
+    fn render_title(&self, _destination: &ReportUploadLocation) -> Result<String> {
+        let mut env = Environment::new();
+        let _ = env.add_template("title", self.get_title_template())?;
+
+        let template = env.get_template("title")?;
+        let rendered = template.render(context! { entrypoint => self.entrypoint })?;
+
+        Ok(rendered)
+    }
+
+    fn render_body(&self, _destination: &ReportUploadLocation) -> Result<String> {
+        let mut env = Environment::new();
+        let _ = env.add_template("body", self.get_body_template())?;
+        let template = env.get_template("body")?;
+
+        let message = self.render_message()?;
+
+        let ctx = context! {
+            message => message,
+            entrypoint => self.entrypoint,
+            // convert to vec[vec[]] because minijinja does not suppport items on Dict
+            // https://github.com/mitsuhiko/minijinja/issues/32
+            additionalData => Vec::from_iter(self.additional_data.iter()),
+         };
+        println!("{:?}", ctx);
+        let rendered = template.render(ctx)?;
+
+        Ok(rendered)
+    }
+
+    fn render_message(&self) -> Result<String> {
+        let mut env = Environment::new();
+        env.add_template("message", &self.message_template)?;
+        let template = env.get_template("message")?;
+        let template = template.render(context! { command => self.entrypoint })?;
+
+        Ok(template)
+    }
+
+    fn get_body_template(&self) -> &str {
+        include_str!("unstructured_body.jinja")
+    }
+
+    fn get_title_template(&self) -> &str {
+        "Scope bug report: `{{ entrypoint }}`"
+    }
+}
+
+// Grouped reports
+#[async_trait]
+pub trait GroupedReportBuilder {
+    fn append_group(&mut self, group_result: &GroupReport) -> Result<()>;
+
+    async fn run_and_append_additional_data(&mut self, found_config: &FoundConfig, exec_provider: Arc<dyn ExecutionProvider>, commands: &BTreeMap<String, String>) -> Result<()>;
+}
+
+pub struct DefaultGroupedReportBuilder {
+    entrypoint: String,
+    groups: Vec<GroupReport>,
+    additional_data: BTreeMap<String, String>,
+    message_template: Option<String>,
+}
+
+impl DefaultGroupedReportBuilder {
+    pub fn new(report: &Option<ReportDefinition>, entrypoint: &str) -> Self {
+        Self {
+            entrypoint: entrypoint.to_string(),
+            groups: vec![],
+            additional_data: BTreeMap::new(),
+            message_template: report.as_ref().map(|report| report.template.clone()),
+        }
+    }
+}
+
+#[async_trait]
+impl GroupedReportBuilder for DefaultGroupedReportBuilder {
+    fn append_group(&mut self, group_result: &GroupReport) -> Result<()> {
+        self.groups.push(group_result.clone());
+
+        Ok(())
+    }
+
+    async fn run_and_append_additional_data(&mut self, found_config: &FoundConfig, exec_provider: Arc<dyn ExecutionProvider>, commands: &BTreeMap<String, String>) -> Result<()> {
+        for (name, command) in commands {
+            let output = exec_provider
+                .run_for_output(&found_config.bin_path, &found_config.working_dir, command)
+                .await;
+            self.additional_data.insert(name.to_string(), output);
+        }
+
+        Ok(())
+    }
+}
+
+impl ReportRenderer for DefaultGroupedReportBuilder {
+    fn render(&self, destination: &ReportUploadLocation) -> Result<Report> {
+        let title = self.render_title(destination)?;
+        let body = self.render_body(destination)?;
+
+        Ok(Report { title, body, destination: destination.clone() })
+    }
+}
+
+impl DefaultGroupedReportBuilder {
+    fn render_title(&self, _destination: &ReportUploadLocation) -> Result<String> {
+        let mut env = Environment::new();
+        let _ = env.add_template("title", self.get_title_template())?;
+
+        let template = env.get_template("title")?;
+        let rendered = template.render(context! { entrypoint => self.entrypoint })?;
+
+        Ok(rendered)
+    }
+
+    fn render_body(&self, _destination: &ReportUploadLocation) -> Result<String> {
+        let mut env = Environment::new();
+        let _ = env.add_template("body", self.get_body_template())?;
+        let template = env.get_template("body")?;
+
+        let message = self.render_message()?;
+
+        let ctx = context! {
+            entrypoint => self.entrypoint,
+            message => message,
+            groups => (&self.groups).into_iter().map(|group| ReportGroupItemContext::from(&group)).collect_vec(),
+            // convert to vec[vec[]] because minijinja does not suppport items on Dict
+            // https://github.com/mitsuhiko/minijinja/issues/32
+            additionalData => Vec::from_iter(self.additional_data.iter()),
+         };
+        let rendered = template.render(ctx)?;
+
+        Ok(rendered)
+    }
+
+    fn render_message(&self) -> Result<String> {
+        match &self.message_template {
+            Some(template) => {
+                let mut env = Environment::new();
+                env.add_template("message", &template)?;
+                let template = env.get_template("message")?;
+                let template = template.render(context! { command => self.entrypoint })?;
+
+                Ok(template)
+            }
+            // Assumption: empty string results in a falsy "if message" in the body template
+            None => Ok("".to_string())
+        }
+    }
+
+    fn get_body_template(&self) -> &str {
+        include_str!("grouped_body.jinja")
+    }
+
+    fn get_title_template(&self) -> &str {
+        "Scope bug report: `{{ entrypoint }}`"
+    }
+}
+
+// Rendering objects
+#[derive(Serialize, Deserialize, Debug)]
+struct ReportCommandResultContext {
+    command: String,
+
+    #[serde(rename = "exitCode")]
+    exit_code: i32,
+
+    #[serde(rename = "startTime")]
+    start_time: String,
+
+    #[serde(rename = "endTime")]
+    end_time: String,
+}
+
+impl ReportCommandResultContext {
+    fn from(report: &ActionTaskReport) -> Self {
+        Self {
+            command: report.command.to_string(),
+            exit_code: report.exit_code.unwrap_or(-1),
+            start_time: report.start_time.to_string(),
+            end_time: report.end_time.to_string(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct ReportGroupItemContext {
+    name: String,
+
+    #[serde(default)]
+    actions: Vec<ReportActionItemContext>,
+}
+
+impl ReportGroupItemContext {
+    fn from(report: &GroupReport) -> Self {
+        Self {
+            name: report.group_name.to_string(),
+            actions: (&report.action_result).into_iter().map(|action| ReportActionItemContext::from(&action)).collect::<Vec<_>>()
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct ReportActionItemContext {
+    name: String,
+
+    #[serde(default)]
+    check: Vec<ReportCommandResultContext>,
+
+    #[serde(default)]
+    fix: Vec<ReportCommandResultContext>,
+
+    #[serde(default)]
+    verify: Vec<ReportCommandResultContext>,
+}
+
+impl ReportActionItemContext {
+    fn from(report: &ActionReport) -> Self {
+        Self {
+            name: report.action_name.to_string(),
+            check: (&report.check)
+                .into_iter()
+                .map(|check| ReportCommandResultContext::from(&check) )
+                .collect::<Vec<_>>(),
+            fix: (&report.fix)
+                .into_iter()
+                .map(|check| ReportCommandResultContext::from(&check) )
+                .collect::<Vec<_>>(),
+            verify: (&report.validate)
+                .into_iter()
+                .map(|check| ReportCommandResultContext::from(&check) )
+                .collect::<Vec<_>>(),
+         }
     }
 }

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -335,6 +335,8 @@ impl DefaultUnstructuredReportBuilder {
 
     fn render_body(&self, _destination: &ReportUploadLocation) -> Result<String> {
         let mut env = Environment::new();
+        env.set_trim_blocks(true);
+        env.set_lstrip_blocks(true);
         env.add_template("body", self.get_body_template())?;
         let template = env.get_template("body")?;
 
@@ -480,7 +482,6 @@ impl DefaultGroupedReportBuilder {
 
                 Ok(template)
             }
-            // Assumption: empty string results in a falsy "if message" in the body template
             None => Ok("".to_string()),
         }
     }

--- a/scope/src/shared/unstructured_body.jinja
+++ b/scope/src/shared/unstructured_body.jinja
@@ -8,6 +8,6 @@
 | Name | Value |
 |---|---|
 {% for data in additionalData %}
-{{ data[0] }}|<pre>{{ data[1] }}</pre>|
+|{{ data.name }}|`{{ data.output }}`|
 {% endfor %}
 {% endif %}

--- a/scope/src/shared/unstructured_body.jinja
+++ b/scope/src/shared/unstructured_body.jinja
@@ -1,0 +1,13 @@
+{%- if message -%}
+{{message}}
+{%- endif %}
+
+{%- if additionalData -%}
+**Additional Capture Data**
+
+| Name | Value |
+|---|---|
+{%- for data in additionalData %}
+{{ data[0] }}|<pre>{{ data[1] }}</pre>|
+{%- endfor %}
+{%- endif %}

--- a/scope/src/shared/unstructured_body.jinja
+++ b/scope/src/shared/unstructured_body.jinja
@@ -1,13 +1,13 @@
-{%- if message -%}
+{% if message %}
 {{message}}
-{%- endif %}
 
-{%- if additionalData -%}
+{% endif %}
+{% if additionalData %}
 **Additional Capture Data**
 
 | Name | Value |
 |---|---|
-{%- for data in additionalData %}
+{% for data in additionalData %}
 {{ data[0] }}|<pre>{{ data[1] }}</pre>|
-{%- endfor %}
-{%- endif %}
+{% endfor %}
+{% endif %}

--- a/scope/src/shared/unstructured_body.jinja
+++ b/scope/src/shared/unstructured_body.jinja
@@ -1,7 +1,7 @@
 {% if message %}
 {{message}}
-
 {% endif %}
+
 {% if additionalData %}
 **Additional Capture Data**
 

--- a/scope/src/shared/unstructured_body.jinja
+++ b/scope/src/shared/unstructured_body.jinja
@@ -5,7 +5,7 @@
 ## Command `{{ result.command }}`
 
 {% if result.output %}
-Output
+Output:
 ```text
 {{ result.output }}
 ```

--- a/scope/src/shared/unstructured_body.jinja
+++ b/scope/src/shared/unstructured_body.jinja
@@ -23,6 +23,6 @@ Output:
 | Name | Value |
 |---|---|
 {% for data in additionalData %}
-|{{ data.name }}|`{{ data.output }}`|
+|{{ data.name }}|{% if data.output %}`{{ data.output }}`{% endif %}|
 {% endfor %}
 {% endif %}

--- a/scope/src/shared/unstructured_body.jinja
+++ b/scope/src/shared/unstructured_body.jinja
@@ -2,6 +2,21 @@
 {{message}}
 {% endif %}
 
+## Command `{{ result.command }}`
+
+{% if result.output %}
+Output
+```text
+{{ result.output }}
+```
+
+{% endif %}
+|Name|Value|
+|:---|:---|
+| Exit code| `{{ result.exitCode }}` |
+| Started at| `{{ result.startTime }}` |
+| Finished at| `{{ result.endTime }}` |
+
 {% if additionalData %}
 **Additional Capture Data**
 


### PR DESCRIPTION
This PR refactors the report rendering implementation to use jinja templates. This paves the way for per-location or configurable templates. 

Tests of report rendering were also added. There is a lot of new code added here, and some feels duplicative. I'd like to follow up this PR with a refactoring one that massages things a little more.

Manual test output to follow in comments.