### PR TITLE
Make OpenTelemetry protocol configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.28",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
@@ -1306,11 +1320,11 @@ dependencies = [
  "hyper 1.2.0",
  "hyper-util",
  "log",
- "rustls",
- "rustls-native-certs",
+ "rustls 0.22.3",
+ "rustls-native-certs 0.7.0",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tower-service",
 ]
 
@@ -1987,7 +2001,7 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.2.0",
- "hyper-rustls",
+ "hyper-rustls 0.26.0",
  "hyper-timeout 0.5.1",
  "hyper-util",
  "jsonwebtoken",
@@ -2083,6 +2097,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-http"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 0.2.12",
+ "opentelemetry",
+ "reqwest 0.11.27",
+]
+
+[[package]]
 name = "opentelemetry-otlp"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2092,6 +2119,7 @@ dependencies = [
  "futures-core",
  "http 0.2.12",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
@@ -2456,6 +2484,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -2463,12 +2492,16 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "system-configuration",
  "tokio",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2493,7 +2526,7 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.2.0",
- "hyper-rustls",
+ "hyper-rustls 0.26.0",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -2505,8 +2538,8 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.22.3",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2515,7 +2548,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.25.0",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2561,6 +2594,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
@@ -2568,9 +2613,21 @@ dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.102.2",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2580,10 +2637,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2601,6 +2667,16 @@ name = "rustls-pki-types"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -2672,6 +2748,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "secrecy"
@@ -3170,11 +3256,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls",
+ "rustls 0.22.3",
  "rustls-pki-types",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ secrecy = "0.8.0"
 url = "2.5.0"
 dotenvy = "0.15.7"
 opentelemetry = { version = "0.22.0", features = ["metrics"] }
-opentelemetry-otlp = { version = "0.15.0", features = ["metrics", "reqwest"] }
+opentelemetry-otlp = { version = "0.15.0", features = ["metrics", "reqwest", "http-proto", "reqwest-client", "reqwest-rustls"] }
 tracing-opentelemetry = "0.23.0"
 opentelemetry_sdk = { version = "0.22.1", features = ["metrics", "rt-tokio"] }
 tonic = "0.11.0"

--- a/scope/src/shared/logging.rs
+++ b/scope/src/shared/logging.rs
@@ -3,7 +3,7 @@ use gethostname::gethostname;
 use indicatif::ProgressStyle;
 use lazy_static::lazy_static;
 use opentelemetry::{global, KeyValue};
-use opentelemetry_otlp::{TonicExporterBuilder, WithExportConfig};
+use opentelemetry_otlp::{HttpExporterBuilder, TonicExporterBuilder, WithExportConfig};
 use opentelemetry_sdk::metrics::reader::{DefaultAggregationSelector, DefaultTemporalitySelector};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::trace::Tracer;
@@ -160,7 +160,7 @@ impl LoggingOpts {
         }
     }
 
-    fn make_exporter(&self, id: &str) -> TonicExporterBuilder {
+    fn make_exporter(&self, id: &str) -> HttpExporterBuilder {
         let endpoint = self.otel_collector.clone().unwrap();
         let mut map = MetadataMap::with_capacity(2);
 
@@ -175,10 +175,10 @@ impl LoggingOpts {
         map.insert("scope.id", id.parse().unwrap());
 
         opentelemetry_otlp::new_exporter()
-            .tonic()
+            .http()
             .with_endpoint(endpoint)
             .with_timeout(Duration::from_secs(3))
-            .with_metadata(map)
+        // .with_metadata(map)
     }
 
     fn setup_otel(&self, run_id: &str) -> Result<Option<OtelProperties>, anyhow::Error> {

--- a/scope/src/shared/logging.rs
+++ b/scope/src/shared/logging.rs
@@ -3,7 +3,10 @@ use gethostname::gethostname;
 use indicatif::ProgressStyle;
 use lazy_static::lazy_static;
 use opentelemetry::{global, KeyValue};
-use opentelemetry_otlp::{HttpExporterBuilder, TonicExporterBuilder, WithExportConfig};
+use opentelemetry_otlp::{
+    HttpExporterBuilder, MetricsExporterBuilder, SpanExporterBuilder, TonicExporterBuilder,
+    WithExportConfig,
+};
 use opentelemetry_sdk::metrics::reader::{DefaultAggregationSelector, DefaultTemporalitySelector};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use opentelemetry_sdk::trace::Tracer;
@@ -85,10 +88,24 @@ pub struct LoggingOpts {
     #[clap(long = "otel-collector", env = "SCOPE_OTEL_ENDPOINT", global(true))]
     otel_collector: Option<String>,
 
+    #[clap(
+        long = "otel-protocol",
+        env = "SCOPE_OTEL_PROTOCOL",
+        global(true),
+        default_value = "grpc"
+    )]
+    otel_protocol: OtelProtocol,
+
     /// When set, we'll send debug details to otel endpoint.
     /// This option is hidden when running --help
     #[arg(long, hide = true, global(true))]
     pub otel_debug: bool,
+}
+
+#[derive(ValueEnum, Debug, Copy, Clone)]
+pub enum OtelProtocol {
+    Http,
+    Grpc,
 }
 
 #[derive(ValueEnum, Debug, Copy, Clone)]
@@ -147,6 +164,7 @@ impl LoggingOpts {
             progress: self.progress,
             default_level: new_default,
             otel_collector: self.otel_collector.clone(),
+            otel_protocol: self.otel_protocol,
             otel_debug: self.otel_debug,
         }
     }
@@ -160,7 +178,7 @@ impl LoggingOpts {
         }
     }
 
-    fn make_exporter(&self, id: &str) -> HttpExporterBuilder {
+    fn make_tonic_exporter(&self, id: &str) -> TonicExporterBuilder {
         let endpoint = self.otel_collector.clone().unwrap();
         let mut map = MetadataMap::with_capacity(2);
 
@@ -175,10 +193,33 @@ impl LoggingOpts {
         map.insert("scope.id", id.parse().unwrap());
 
         opentelemetry_otlp::new_exporter()
+            .tonic()
+            .with_endpoint(endpoint)
+            .with_timeout(Duration::from_secs(3))
+            .with_metadata(map)
+    }
+
+    fn make_http_exporter(&self) -> HttpExporterBuilder {
+        let endpoint = self.otel_collector.clone().unwrap();
+
+        opentelemetry_otlp::new_exporter()
             .http()
             .with_endpoint(endpoint)
             .with_timeout(Duration::from_secs(3))
-        // .with_metadata(map)
+    }
+
+    fn make_span_exporter_builder(&self, id: &str) -> SpanExporterBuilder {
+        match self.otel_protocol {
+            OtelProtocol::Grpc => SpanExporterBuilder::Tonic(self.make_tonic_exporter(id)),
+            OtelProtocol::Http => SpanExporterBuilder::Http(self.make_http_exporter()),
+        }
+    }
+
+    fn make_metrics_exporter_builder(&self, id: &str) -> MetricsExporterBuilder {
+        match self.otel_protocol {
+            OtelProtocol::Grpc => MetricsExporterBuilder::Tonic(self.make_tonic_exporter(id)),
+            OtelProtocol::Http => MetricsExporterBuilder::Http(self.make_http_exporter()),
+        }
     }
 
     fn setup_otel(&self, run_id: &str) -> Result<Option<OtelProperties>, anyhow::Error> {
@@ -194,9 +235,10 @@ impl LoggingOpts {
                 ),
                 KeyValue::new("scope.id", run_id.to_string()),
             ]);
+
             let tracer = opentelemetry_otlp::new_pipeline()
                 .tracing()
-                .with_exporter(self.make_exporter(run_id))
+                .with_exporter(self.make_span_exporter_builder(run_id))
                 .with_trace_config(
                     trace::config()
                         .with_sampler(Sampler::AlwaysOn)
@@ -210,7 +252,7 @@ impl LoggingOpts {
 
             let metrics = opentelemetry_otlp::new_pipeline()
                 .metrics(opentelemetry_sdk::runtime::Tokio)
-                .with_exporter(self.make_exporter(run_id))
+                .with_exporter(self.make_metrics_exporter_builder(run_id))
                 .with_resource(resources)
                 .with_period(Duration::from_secs(3))
                 .with_timeout(Duration::from_secs(10))


### PR DESCRIPTION
At Gusto, our OpenTelemetry endpoint is accessible via http only. This PR makes the protocol configurable via the `SCOPE_OTEL_PROTOCOL` environment variable.

The change was mostly a noop, except the omission of the `with_metadata` call on the `HttpExporterBuilder`. It looks like `with_metadata` is [only available on the gRPC builder](https://docs.rs/opentelemetry-otlp/latest/opentelemetry_otlp/struct.HttpExporterBuilder.html).

```
❯ ./target/debug/scope --help
...
Options:
...
      --otel-collector <OTEL_COLLECTOR>
          When set metrics will be sent to an otel collector at the endpoint provided

          [env: SCOPE_OTEL_ENDPOINT=]

      --otel-protocol <OTEL_PROTOCOL>
          [env: SCOPE_OTEL_PROTOCOL=]
          [default: grpc]
          [possible values: http, grpc]
...
```

## Testing

<details>
<summary>Correct protocol</summary>

```
❯ SCOPE_OTEL_ENDPOINT=https://devotel.uw2.staging.zp-int.com SCOPE_OTEL_PROTOCOL=http ./target/debug/scope list
  Name                  Description                                                 Path
  Name                Description
- analyze             Analyze for known errors
- doctor              Run checks that will "checkup" your machine
- intercept           External sub-command, run `scope intercept` for help
- lint                Validate inputs, providing recommendations about configuration
- list                List the found config files, and resources detected
- report              Generate a bug report based from a command that was ran
- version             Print version info and exit
```

</details>

<details>
<summary>Incorrect protocol</summary>

```
❯ SCOPE_OTEL_ENDPOINT=https://devotel.uw2.staging.zp-int.com SCOPE_OTEL_PROTOCOL=grpc ./target/debug/scope list
  Name                  Description                                                 Path
  Name                Description
- analyze             Analyze for known errors
- doctor              Run checks that will "checkup" your machine
- intercept           External sub-command, run `scope intercept` for help
- lint                Validate inputs, providing recommendations about configuration
- list                List the found config files, and resources detected
- report              Generate a bug report based from a command that was ran
- version             Print version info and exit
OpenTelemetry trace error occurred. Exporter otlp encountered the following error(s): the grpc server returns error (Unknown error): , detailed error message: transport error
```

</details>