### PR TITLE
Fix rendering of multi-line additional data in reports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7165d0e94806d52ad5295e4b54a95176d831814840bc067298ca647e1c956338"
+checksum = "e136ef580d7955019ab0a407b68d77c292a9976907e217900f3f76bc8f6dc1a4"
 dependencies = [
  "memo-map",
  "self_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ derivative = "2"
 reqwest = { version = "0.12", features = ["multipart", "rustls-tls", "native-tls-vendored" ] }
 time = { version = "0.3", features = ["macros", "formatting", "local-offset"] }
 json = "0.12"
-minijinja = { version = "2.0", features = ["loader"] }
+minijinja = { version = "2.0.2", features = ["loader"] }
 itertools = { version = "0.13", features = [] }
 path-clean = "1.0.1"
 async-trait = "0.1.80"

--- a/scope/src/shared/grouped_body.jinja
+++ b/scope/src/shared/grouped_body.jinja
@@ -77,7 +77,7 @@ Output:
 | Name | Value |
 |---|---|
 {% for data in group.additionalData %}
-|{{ data.name }}|{% if data.output %}`{{ data.output|split("\n")|map("trim")|join(", ") }}`{% endif %}|
+|{{ data.name }}|{% if data.output %}`{{ data.output|split("\n")|map("trim")|join("`<br>`") }}`{% endif %}|
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/scope/src/shared/grouped_body.jinja
+++ b/scope/src/shared/grouped_body.jinja
@@ -77,7 +77,7 @@ Output:
 | Name | Value |
 |---|---|
 {% for data in group.additionalData %}
-|{{ data.name }}|{% if data.output %}`{{ data.output }}`{% endif %}|
+|{{ data.name }}|{% if data.output %}`{{ data.output|split("\n")|map("trim")|join(", ") }}`{% endif %}|
 {% endfor %}
 {% endif %}
 {% endfor %}

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -692,13 +692,22 @@ second line
             additional_data: Default::default(),
         };
 
-        let additional_data = BTreeMap::from([("baz".to_string(), "baz".to_string())]);
+        let additional_data = BTreeMap::from([
+            ("baz".to_string(), "baz".to_string()),
+            ("lines".to_string(), "lines".to_string()),
+        ]);
 
         exec_provider
             .expect_run_for_output()
             .times(1)
             .withf(move |_, _, command| command.eq("baz"))
             .returning(move |_, _, _| "qux".to_string());
+
+        exec_provider
+            .expect_run_for_output()
+            .times(1)
+            .withf(move |_, _, command| command.eq("lines"))
+            .returning(move |_, _, _| "line 1\nline2".to_string());
 
         let capture = OutputCaptureBuilder::default()
             .command("hello world")
@@ -751,6 +760,7 @@ stderr
 | Name | Value |
 |---|---|
 |baz|`qux`|
+|lines|`line 1, line2`|
 "
         .to_string();
         assert_eq!(expected_body, report.body);

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -760,7 +760,7 @@ stderr
 | Name | Value |
 |---|---|
 |baz|`qux`|
-|lines|`line 1, line2`|
+|lines|`line 1`<br>`line2`|
 "
         .to_string();
         assert_eq!(expected_body, report.body);

--- a/scope/src/shared/unstructured_body.jinja
+++ b/scope/src/shared/unstructured_body.jinja
@@ -22,6 +22,6 @@ Output:
 | Name | Value |
 |---|---|
 {% for data in additionalData %}
-|{{ data.name }}|{% if data.output %}`{{ data.output|split("\n")|map("trim")|join(", ") }}`{% endif %}|
+|{{ data.name }}|{% if data.output %}`{{ data.output|split("\n")|map("trim")|join("`<br>`") }}`{% endif %}|
 {% endfor %}
 {% endif %}

--- a/scope/src/shared/unstructured_body.jinja
+++ b/scope/src/shared/unstructured_body.jinja
@@ -22,6 +22,6 @@ Output:
 | Name | Value |
 |---|---|
 {% for data in additionalData %}
-|{{ data.name }}|{% if data.output %}`{{ data.output }}`{% endif %}|
+|{{ data.name }}|{% if data.output %}`{{ data.output|split("\n")|map("trim")|join(", ") }}`{% endif %}|
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
I noticed the new report template doesn't handle multi-line additional data values well in the markdown table cell.

This PR collapses multi-line output to be comma separated.  `trim` was added to clean up excess leading and trailing whitespace.