### PR TITLE
Default to not submit bug reports

### DIFF
--- a/scope/src/bin/scope-intercept.rs
+++ b/scope/src/bin/scope-intercept.rs
@@ -105,7 +105,7 @@ async fn run_command(opts: Cli) -> anyhow::Result<i32> {
     }
 
     let ans = inquire::Confirm::new("Do you want to upload a bug report?")
-        .with_default(true)
+        .with_default(false)
         .with_help_message(
             "This will allow you to share the error with other engineers for support.",
         )

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -81,7 +81,7 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
             true
         } else {
             inquire::Confirm::new("Do you want to upload a bug report?")
-                .with_default(true)
+                .with_default(false)
                 .with_help_message(
                     "This will allow you to share the error with other engineers for support.",
                 )


### PR DESCRIPTION
After deploying scope to a number of users, the majority of the bug reports submitted are accidental from users just pressing `Enter` to get past the prompt.

This PR changes the default for the bug report submission to No:

```
❯ cargo run -- --working-dir examples doctor run --only fail
fail/file-exists:  examples/file-mod.txt1
ERROR Check initially failed, fix ran, verification failed, group: "fail", name: "file-exists"
fail/file-exists:  found file examples/file-mod.txt
Summary: 0 groups succeeded, 1 groups failed, 1 groups skipped

? Do you want to upload a bug report? (y/N)
[This will allow you to share the error with other engineers for support.]
```