### PR TITLE
When check.paths finds no files, fail the check

### DIFF
--- a/docs/docs/models/ScopeDoctorGroup.mdx
+++ b/docs/docs/models/ScopeDoctorGroup.mdx
@@ -64,6 +64,10 @@ The action should be atomic, and target a single resolution.
 Notice an action can provide both `paths` and `commands`, if either of them indicate that the fix should run, it will run.
 In the event there are no defined check, the fix will _always_ run.
 
+`paths` indicate a fix should run when:
+1. No files match any of the `path` globs, or
+2. Any of the matching files contents have changed
+
 ## Fix
 
 When the checks determine that something isn't correct, a fix is the way to automate the resolution.

--- a/scope/schema/merged.json
+++ b/scope/schema/merged.json
@@ -14,7 +14,7 @@
   ],
   "definitions": {
     "DoctorCheckSpec": {
-      "description": "What needs to be checked before the action will run. All `paths` will be checked first, then `commands`. If a `path` has changed, the `command` will not run.",
+      "description": "What needs to be checked before the action will run. `paths` will be checked first, then `commands`. If a `path` matches no files or the matching files have changed, the `command` will run.",
       "type": "object",
       "properties": {
         "commands": {

--- a/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -30,7 +30,7 @@
   "additionalProperties": false,
   "definitions": {
     "DoctorCheckSpec": {
-      "description": "What needs to be checked before the action will run. All `paths` will be checked first, then `commands`. If a `path` has changed, the `command` will not run.",
+      "description": "What needs to be checked before the action will run. `paths` will be checked first, then `commands`. If a `path` matches no files or the matching files have changed, the `command` will run.",
       "type": "object",
       "properties": {
         "commands": {

--- a/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -30,7 +30,7 @@
   "additionalProperties": false,
   "definitions": {
     "DoctorCheckSpec": {
-      "description": "What needs to be checked before the action will run. All `paths` will be checked first, then `commands`. If a `path` has changed, the `command` will not run.",
+      "description": "What needs to be checked before the action will run. `paths` will be checked first, then `commands`. If a `path` matches no files or the matching files have changed, the `command` will run.",
       "type": "object",
       "properties": {
         "commands": {

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -30,7 +30,7 @@
   "additionalProperties": false,
   "definitions": {
     "DoctorCheckSpec": {
-      "description": "What needs to be checked before the action will run. All `paths` will be checked first, then `commands`. If a `path` has changed, the `command` will not run.",
+      "description": "What needs to be checked before the action will run. `paths` will be checked first, then `commands`. If a `path` matches no files or the matching files have changed, the `command` will run.",
       "type": "object",
       "properties": {
         "commands": {

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -542,21 +542,21 @@ impl GlobWalker for DefaultGlobWalker {
         cache_name: &str,
         file_cache: Arc<dyn FileCache>,
     ) -> Result<bool, RuntimeError> {
-        let mut files_found = false;
         for glob_str in paths {
             let glob_path = make_absolute(base_dir, glob_str);
-            for path in self.file_system.find_files(&glob_path)? {
-                files_found = true;
+            let files = self.file_system.find_files(&glob_path)?;
+
+            if files.is_empty() {
+                return Ok(false);
+            }
+
+            for path in files {
                 let file_result = file_cache.check_file(cache_name.to_string(), &path).await?;
                 let check_result = file_result == FileCacheStatus::FileMatches;
                 if !check_result {
                     return Ok(false);
                 }
             }
-        }
-
-        if !files_found {
-            return Ok(false);
         }
 
         Ok(true)

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -542,15 +542,21 @@ impl GlobWalker for DefaultGlobWalker {
         cache_name: &str,
         file_cache: Arc<dyn FileCache>,
     ) -> Result<bool, RuntimeError> {
+        let mut files_found = false;
         for glob_str in paths {
             let glob_path = make_absolute(base_dir, glob_str);
             for path in self.file_system.find_files(&glob_path)? {
+                files_found = true;
                 let file_result = file_cache.check_file(cache_name.to_string(), &path).await?;
                 let check_result = file_result == FileCacheStatus::FileMatches;
                 if !check_result {
                     return Ok(false);
                 }
             }
+        }
+
+        if !files_found {
+            return Ok(false);
         }
 
         Ok(true)

--- a/scope/src/models/v1alpha/doctor_group.rs
+++ b/scope/src/models/v1alpha/doctor_group.rs
@@ -7,8 +7,8 @@ use crate::models::core::ModelMetadata;
 use crate::models::v1alpha::V1AlphaApiVersion;
 use crate::models::{HelpMetadata, InternalScopeModel, ScopeModel};
 
-/// What needs to be checked before the action will run. All `paths` will be checked first, then
-/// `commands`. If a `path` has changed, the `command` will not run.
+/// What needs to be checked before the action will run. `paths` will be checked first, then
+/// `commands`. If a `path` matches no files or the matching files have changed, the `command` will run.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 #[schemars(deny_unknown_fields)]

--- a/scope/tests/scope_doctor.rs
+++ b/scope/tests/scope_doctor.rs
@@ -123,7 +123,7 @@ fn test_templated_file_paths() {
     let result = test_helper.doctor_run(None);
 
     result.success().stdout(predicate::str::contains(
-        "Check was successful, group: \"templated\", name: \"hushlogin\"",
+        "INFO Check initially failed, fix was successful, group: \"templated\", name: \"hushlogin\"",
     ));
 }
 

--- a/scope/tests/scope_doctor.rs
+++ b/scope/tests/scope_doctor.rs
@@ -74,6 +74,18 @@ fn test_able_to_limit_run() {
 }
 
 #[test]
+fn test_nonexistant_file() {
+    let test_helper = ScopeTestHelper::new("test_nonexistant_file", "paths");
+    let result = test_helper.doctor_run(None);
+
+    result.success().stdout(predicate::str::contains(
+        "Check initially failed, fix was successful, group: \"path-checks\", name: \"does-not-exist\"",
+    ));
+
+    test_helper.clean_work_dir();
+}
+
+#[test]
 fn test_cache_invalidation() {
     let test_helper = ScopeTestHelper::new("test_cache_invalidation", "file-cache-check");
 

--- a/scope/tests/test-cases/paths/.scope/group.yaml
+++ b/scope/tests/test-cases/paths/.scope/group.yaml
@@ -1,0 +1,14 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: path-checks
+  description: Run dep install
+spec:
+  actions:
+    - name: does-not-exist
+      check:
+        paths:
+          - nonexistant_file.txt
+      fix:
+        commands:
+          - touch nonexistant_file.txt


### PR DESCRIPTION
This PR adjusts the `check.paths` behavior when there are no matching files found.

Previously, if no files matched, the check would pass. This makes it counter-intuitive for checks that ensure files exist (like `scope/tests/test-cases/templated-check-path`), or for fixes that generate files that may [not be present initially](https://github.com/oscope-dev/scope/issues/152).