### PR TITLE
Refactor have_globs_changed and add non-existant path test

### DIFF
--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -542,21 +542,21 @@ impl GlobWalker for DefaultGlobWalker {
         cache_name: &str,
         file_cache: Arc<dyn FileCache>,
     ) -> Result<bool, RuntimeError> {
-        let mut files_found = false;
         for glob_str in paths {
             let glob_path = make_absolute(base_dir, glob_str);
-            for path in self.file_system.find_files(&glob_path)? {
-                files_found = true;
+            let files = self.file_system.find_files(&glob_path)?;
+
+            if files.is_empty() {
+                return Ok(false);
+            }
+
+            for path in files {
                 let file_result = file_cache.check_file(cache_name.to_string(), &path).await?;
                 let check_result = file_result == FileCacheStatus::FileMatches;
                 if !check_result {
                     return Ok(false);
                 }
             }
-        }
-
-        if !files_found {
-            return Ok(false);
         }
 
         Ok(true)

--- a/scope/tests/scope_doctor.rs
+++ b/scope/tests/scope_doctor.rs
@@ -74,6 +74,18 @@ fn test_able_to_limit_run() {
 }
 
 #[test]
+fn test_nonexistant_file() {
+    let test_helper = ScopeTestHelper::new("test_nonexistant_file", "paths");
+    let result = test_helper.doctor_run(None);
+
+    result.success().stdout(predicate::str::contains(
+        "Check initially failed, fix was successful, group: \"path-checks\", name: \"does-not-exist\"",
+    ));
+
+    test_helper.clean_work_dir();
+}
+
+#[test]
 fn test_cache_invalidation() {
     let test_helper = ScopeTestHelper::new("test_cache_invalidation", "file-cache-check");
 

--- a/scope/tests/test-cases/paths/.scope/group.yaml
+++ b/scope/tests/test-cases/paths/.scope/group.yaml
@@ -1,0 +1,14 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: path-checks
+  description: Run dep install
+spec:
+  actions:
+    - name: does-not-exist
+      check:
+        paths:
+          - nonexistant_file.txt
+      fix:
+        commands:
+          - touch nonexistant_file.txt


### PR DESCRIPTION
Suggested improvements to #155 

Rather than keep track of mutable state, check to see if the resulting `vec` is empty and return early if so.  
Also adds a test for the specific use case.