### PR TITLE
Include group and action names in traces

### DIFF
--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -148,7 +148,7 @@ where
                 continue;
             }
 
-            let group_span = info_span!(parent: &header_span, "group", "indicatif.pb_show" = true);
+            let group_span = info_span!(parent: &header_span, "group", "indicatif.pb_show" = true, "group.name" = group_name);
             group_span.pb_set_length(group_container.actions.len() as u64);
             group_span.pb_set_message(&format!("group {}", group_name));
             let _span = group_span.enter();
@@ -181,7 +181,7 @@ where
                 continue;
             }
 
-            let action_span = info_span!(parent: group_span, "action", "indicatif.pb_show" = true);
+            let action_span = info_span!(parent: group_span, "action", "indicatif.pb_show" = true, "action.name" = action.name());
             action_span.pb_set_message(&format!(
                 "action {} - {}",
                 action.name(),


### PR DESCRIPTION
This PR adds group and action names to the traces emitted, making it possible to determine which actions are taking the most time to run, or fail the most often. Resolves https://github.com/oscope-dev/scope/issues/154

Dynamic trace names [are discouraged](https://stackoverflow.com/questions/65735619/how-to-use-a-dynamic-span-name-with-tracing) by `tracing`'s `const` trace name argument, so names are provided as fields.

![Screenshot 2024-10-17 at 9 38 20 AM](https://github.com/user-attachments/assets/855e5822-5c05-414f-9cd9-1f5094f228b3)

![Screenshot 2024-10-17 at 9 38 15 AM](https://github.com/user-attachments/assets/2cda7c51-a2ee-47fd-9f8e-2c8a65c26bff)
