### PR TITLE
Add ability to prompt user before applying fix

### DIFF
--- a/examples/.scope/doctor-group-prompt.yaml
+++ b/examples/.scope/doctor-group-prompt.yaml
@@ -1,0 +1,21 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: prompt
+  description: Ask user if they want to run the fix
+spec:
+  include: when-required
+  actions:
+    - name: prompt-user
+      description: >-
+        Checks for an issue with a potentially destructive fix and 
+        prompts the user for permission before running the fix.
+      check:
+        commands:
+          - sleep 5 #gives the progress bar time to display
+          - test -f .prompt-check
+      fix:
+        autofix: false #this is the magic sauce that displays the user prompt
+        commands:
+          - sleep 5 #gives the progress bar time to display
+          - touch .prompt-check

--- a/examples/.scope/doctor-group-prompt.yaml
+++ b/examples/.scope/doctor-group-prompt.yaml
@@ -15,7 +15,9 @@ spec:
           - sleep 5 #gives the progress bar time to display
           - test -f .prompt-check
       fix:
-        autofix: false #this is the magic sauce that displays the user prompt
+        prompt: |- 
+          This may destroy some data.
+          Do you wish to continue?
         commands:
           - sleep 5 #gives the progress bar time to display
           - touch .prompt-check

--- a/examples/.scope/doctor-group-prompt.yaml
+++ b/examples/.scope/doctor-group-prompt.yaml
@@ -8,16 +8,21 @@ spec:
   actions:
     - name: prompt-user
       description: >-
-        Checks for an issue with a potentially destructive fix and 
+        Checks for an issue with a potentially destructive fix and
         prompts the user for permission before running the fix.
       check:
         commands:
           - sleep 5 #gives the progress bar time to display
           - test -f .prompt-check
       fix:
-        prompt: |- 
-          This may destroy some data.
-          Do you wish to continue?
+        prompt:
+          text: |-
+            This may destroy some data.
+            Do you wish to continue?
+          # this is an optional field
+          extraContext: >-
+            Some additional context about why this needs approval
+            and what it's actually doing
         commands:
           - sleep 5 #gives the progress bar time to display
           - touch .prompt-check

--- a/scope/schema/merged.json
+++ b/scope/schema/merged.json
@@ -44,6 +44,26 @@
       },
       "additionalProperties": false
     },
+    "DoctorFixPromptSpec": {
+      "type": "object",
+      "properties": {
+        "extraContext": {
+          "description": "Additional context for why they're being prompted for approval",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ],
+          "nullable": true
+        },
+        "text": {
+          "description": "Yes/No question presented to the user",
+          "default": "",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "DoctorFixSpec": {
       "description": "Definition for fixing the environment.",
       "type": "object",
@@ -75,10 +95,15 @@
           "nullable": true
         },
         "prompt": {
+          "description": "When present, user will be prompted for approval before running the fix",
           "default": null,
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DoctorFixPromptSpec"
+            },
+            {
+              "type": "null"
+            }
           ],
           "nullable": true
         }

--- a/scope/schema/merged.json
+++ b/scope/schema/merged.json
@@ -48,6 +48,11 @@
       "description": "Definition for fixing the environment.",
       "type": "object",
       "properties": {
+        "autofix": {
+          "description": "When false, prompt the user before running the fix. Defaults to true.",
+          "default": true,
+          "type": "boolean"
+        },
         "commands": {
           "description": "List of commands to run to fix the env.",
           "default": [],

--- a/scope/schema/merged.json
+++ b/scope/schema/merged.json
@@ -48,11 +48,6 @@
       "description": "Definition for fixing the environment.",
       "type": "object",
       "properties": {
-        "autofix": {
-          "description": "When false, prompt the user before running the fix. Defaults to true.",
-          "default": true,
-          "type": "boolean"
-        },
         "commands": {
           "description": "List of commands to run to fix the env.",
           "default": [],
@@ -72,6 +67,14 @@
         },
         "helpUrl": {
           "description": "Link to documentation to fix the issue.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ],
+          "nullable": true
+        },
+        "prompt": {
           "default": null,
           "type": [
             "string",

--- a/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -64,6 +64,11 @@
       "description": "Definition for fixing the environment.",
       "type": "object",
       "properties": {
+        "autofix": {
+          "description": "When false, prompt the user before running the fix. Defaults to true.",
+          "default": true,
+          "type": "boolean"
+        },
         "commands": {
           "description": "List of commands to run to fix the env.",
           "default": [],

--- a/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -64,11 +64,6 @@
       "description": "Definition for fixing the environment.",
       "type": "object",
       "properties": {
-        "autofix": {
-          "description": "When false, prompt the user before running the fix. Defaults to true.",
-          "default": true,
-          "type": "boolean"
-        },
         "commands": {
           "description": "List of commands to run to fix the env.",
           "default": [],
@@ -88,6 +83,14 @@
         },
         "helpUrl": {
           "description": "Link to documentation to fix the issue.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ],
+          "nullable": true
+        },
+        "prompt": {
           "default": null,
           "type": [
             "string",

--- a/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -60,6 +60,26 @@
       },
       "additionalProperties": false
     },
+    "DoctorFixPromptSpec": {
+      "type": "object",
+      "properties": {
+        "extraContext": {
+          "description": "Additional context for why they're being prompted for approval",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ],
+          "nullable": true
+        },
+        "text": {
+          "description": "Yes/No question presented to the user",
+          "default": "",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "DoctorFixSpec": {
       "description": "Definition for fixing the environment.",
       "type": "object",
@@ -91,10 +111,15 @@
           "nullable": true
         },
         "prompt": {
+          "description": "When present, user will be prompted for approval before running the fix",
           "default": null,
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DoctorFixPromptSpec"
+            },
+            {
+              "type": "null"
+            }
           ],
           "nullable": true
         }

--- a/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -64,6 +64,11 @@
       "description": "Definition for fixing the environment.",
       "type": "object",
       "properties": {
+        "autofix": {
+          "description": "When false, prompt the user before running the fix. Defaults to true.",
+          "default": true,
+          "type": "boolean"
+        },
         "commands": {
           "description": "List of commands to run to fix the env.",
           "default": [],

--- a/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -64,11 +64,6 @@
       "description": "Definition for fixing the environment.",
       "type": "object",
       "properties": {
-        "autofix": {
-          "description": "When false, prompt the user before running the fix. Defaults to true.",
-          "default": true,
-          "type": "boolean"
-        },
         "commands": {
           "description": "List of commands to run to fix the env.",
           "default": [],
@@ -88,6 +83,14 @@
         },
         "helpUrl": {
           "description": "Link to documentation to fix the issue.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ],
+          "nullable": true
+        },
+        "prompt": {
           "default": null,
           "type": [
             "string",

--- a/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -60,6 +60,26 @@
       },
       "additionalProperties": false
     },
+    "DoctorFixPromptSpec": {
+      "type": "object",
+      "properties": {
+        "extraContext": {
+          "description": "Additional context for why they're being prompted for approval",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ],
+          "nullable": true
+        },
+        "text": {
+          "description": "Yes/No question presented to the user",
+          "default": "",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "DoctorFixSpec": {
       "description": "Definition for fixing the environment.",
       "type": "object",
@@ -91,10 +111,15 @@
           "nullable": true
         },
         "prompt": {
+          "description": "When present, user will be prompted for approval before running the fix",
           "default": null,
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DoctorFixPromptSpec"
+            },
+            {
+              "type": "null"
+            }
           ],
           "nullable": true
         }

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -64,6 +64,11 @@
       "description": "Definition for fixing the environment.",
       "type": "object",
       "properties": {
+        "autofix": {
+          "description": "When false, prompt the user before running the fix. Defaults to true.",
+          "default": true,
+          "type": "boolean"
+        },
         "commands": {
           "description": "List of commands to run to fix the env.",
           "default": [],

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -64,11 +64,6 @@
       "description": "Definition for fixing the environment.",
       "type": "object",
       "properties": {
-        "autofix": {
-          "description": "When false, prompt the user before running the fix. Defaults to true.",
-          "default": true,
-          "type": "boolean"
-        },
         "commands": {
           "description": "List of commands to run to fix the env.",
           "default": [],
@@ -88,6 +83,14 @@
         },
         "helpUrl": {
           "description": "Link to documentation to fix the issue.",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ],
+          "nullable": true
+        },
+        "prompt": {
           "default": null,
           "type": [
             "string",

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -60,6 +60,26 @@
       },
       "additionalProperties": false
     },
+    "DoctorFixPromptSpec": {
+      "type": "object",
+      "properties": {
+        "extraContext": {
+          "description": "Additional context for why they're being prompted for approval",
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ],
+          "nullable": true
+        },
+        "text": {
+          "description": "Yes/No question presented to the user",
+          "default": "",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "DoctorFixSpec": {
       "description": "Definition for fixing the environment.",
       "type": "object",
@@ -91,10 +111,15 @@
           "nullable": true
         },
         "prompt": {
+          "description": "When present, user will be prompted for approval before running the fix",
           "default": null,
-          "type": [
-            "string",
-            "null"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DoctorFixPromptSpec"
+            },
+            {
+              "type": "null"
+            }
           ],
           "nullable": true
         }

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -80,13 +80,16 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
         let create_report = if args.auto_publish_report {
             true
         } else {
-            inquire::Confirm::new("Do you want to upload a bug report?")
-                .with_default(false)
-                .with_help_message(
-                    "This will allow you to share the error with other engineers for support.",
-                )
-                .prompt()
-                .unwrap_or(false)
+            // FIXME: CMAC make sure we actually need this suspend when we're done
+            tracing_indicatif::suspend_tracing_indicatif(|| {
+                inquire::Confirm::new("Do you want to upload a bug report?")
+                    .with_default(false)
+                    .with_help_message(
+                        "This will allow you to share the error with other engineers for support.",
+                    )
+                    .prompt()
+                    .unwrap_or(false)
+            })
         };
 
         if create_report {

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -80,7 +80,6 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
         let create_report = if args.auto_publish_report {
             true
         } else {
-            // FIXME: CMAC make sure we actually need this suspend when we're done
             tracing_indicatif::suspend_tracing_indicatif(|| {
                 inquire::Confirm::new("Do you want to upload a bug report?")
                     .with_default(false)

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -75,7 +75,10 @@ pub async fn doctor_run(found_config: &FoundConfig, args: &DoctorRunArgs) -> Res
         warn!(target: "user", "Unable to update cache, re-runs may redo work");
     }
 
-    if !result.did_succeed && !found_config.report_upload.is_empty() {
+    if !result.did_succeed
+        && !result.failed_group.is_empty()
+        && !found_config.report_upload.is_empty()
+    {
         println!();
         let create_report = if args.auto_publish_report {
             true

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -64,6 +64,7 @@ impl PathRunResult {
             }
             GroupExecutionStatus::Skipped => {
                 self.skipped_group.insert(group_name);
+                self.did_succeed = false;
             }
         };
 
@@ -711,7 +712,7 @@ mod tests {
         };
 
         let exit_code = run_groups.execute().await?;
-        assert!(exit_code.did_succeed);
+        assert!(!exit_code.did_succeed);
 
         assert_eq!(
             BTreeSet::from(["succeeds"].map(str::to_string)),
@@ -758,7 +759,7 @@ mod tests {
         };
 
         let exit_code = run_groups.execute().await?;
-        assert!(exit_code.did_succeed);
+        assert!(!exit_code.did_succeed);
         assert_eq!(
             BTreeSet::from(["succeeds_1", "succeeds_2"].map(str::to_string)),
             exit_code.succeeded_groups

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -246,17 +246,12 @@ where
     }
 }
 
-// FIXME: not sure this is the right place to define this
-fn prompt_user() -> bool {
+fn prompt_user(prompt_text: &str) -> bool {
     tracing_indicatif::suspend_tracing_indicatif(|| {
-        // FIXME: I don't like the "dangerous" wording of the prompt. Maybe each fix that has an autoprompt should allow specifying the prompt?
-        // I would also rather not return false if there is some sort of error?
-        inquire::Confirm::new("This fix is potentially dangerous. Would you like to run it?")
+        inquire::Confirm::new(prompt_text)
             .with_default(false)
-            //FIXME: do we want a help message here?
-            // .with_help_message(
-            //     "This will allow you to share the error with other engineers for support.",
-            // )
+            //FIXME: do we want to allow a help message here?
+            // .with_help_message("additional text explaining why this needs approval")
             .prompt()
             .unwrap_or(false)
     })

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -246,14 +246,17 @@ where
     }
 }
 
-fn prompt_user(prompt_text: &str) -> bool {
+fn prompt_user(prompt_text: &str, maybe_help_text: &Option<String>) -> bool {
     tracing_indicatif::suspend_tracing_indicatif(|| {
-        inquire::Confirm::new(prompt_text)
-            .with_default(false)
-            //FIXME: do we want to allow a help message here?
-            // .with_help_message("additional text explaining why this needs approval")
-            .prompt()
-            .unwrap_or(false)
+        let prompt = {
+            let base_prompt = inquire::Confirm::new(prompt_text).with_default(false);
+            match maybe_help_text {
+                Some(help_text) => base_prompt.with_help_message(help_text),
+                None => base_prompt,
+            }
+        };
+
+        prompt.prompt().unwrap_or(false)
     })
 }
 

--- a/scope/src/models/v1alpha/doctor_group.rs
+++ b/scope/src/models/v1alpha/doctor_group.rs
@@ -45,9 +45,22 @@ pub struct DoctorFixSpec {
     #[serde(default)]
     pub help_url: Option<String>,
 
-    // When present, user will be prompted for approval before running the fix
+    /// When present, user will be prompted for approval before running the fix
     #[serde(default)]
-    pub prompt: Option<String>,
+    pub prompt: Option<DoctorFixPromptSpec>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[schemars(deny_unknown_fields)]
+pub struct DoctorFixPromptSpec {
+    /// Yes/No question presented to the user
+    #[serde(default)]
+    pub text: String,
+
+    /// Additional context for why they're being prompted for approval
+    #[serde(default)]
+    pub extra_context: Option<String>,
 }
 
 /// An action is a single step used to check in a group. This is most commonly used to build a

--- a/scope/src/models/v1alpha/doctor_group.rs
+++ b/scope/src/models/v1alpha/doctor_group.rs
@@ -44,6 +44,15 @@ pub struct DoctorFixSpec {
     /// Link to documentation to fix the issue.
     #[serde(default)]
     pub help_url: Option<String>,
+
+    /// When false, prompt the user before running the fix.
+    /// Defaults to true.
+    #[serde(default = "doctor_group_action_fix_autofix_default")]
+    pub autofix: bool,
+}
+
+fn doctor_group_action_fix_autofix_default() -> bool {
+    true
 }
 
 /// An action is a single step used to check in a group. This is most commonly used to build a

--- a/scope/src/models/v1alpha/doctor_group.rs
+++ b/scope/src/models/v1alpha/doctor_group.rs
@@ -45,14 +45,9 @@ pub struct DoctorFixSpec {
     #[serde(default)]
     pub help_url: Option<String>,
 
-    /// When false, prompt the user before running the fix.
-    /// Defaults to true.
-    #[serde(default = "doctor_group_action_fix_autofix_default")]
-    pub autofix: bool,
-}
-
-fn doctor_group_action_fix_autofix_default() -> bool {
-    true
+    // When present, user will be prompted for approval before running the fix
+    #[serde(default)]
+    pub prompt: Option<String>,
 }
 
 /// An action is a single step used to check in a group. This is most commonly used to build a

--- a/scope/src/shared/models/internal/doctor_group.rs
+++ b/scope/src/shared/models/internal/doctor_group.rs
@@ -30,14 +30,14 @@ pub struct DoctorGroupActionFix {
     #[builder(default)]
     pub help_url: Option<String>,
     #[builder(default)]
-    pub autofix: bool,
+    pub prompt: Option<String>,
 }
 
 impl DoctorGroupAction {
     pub fn make_from(
         name: &str,
         description: &str,
-        autofix: bool,
+        prompt: Option<&str>,
         fix_command: Option<Vec<&str>>,
         check_path: Option<(&str, Vec<&str>)>,
         check_command: Option<Vec<&str>>,
@@ -50,7 +50,7 @@ impl DoctorGroupAction {
                 command: fix_command.map(DoctorGroupActionCommand::from),
                 help_text: None,
                 help_url: None,
-                autofix,
+                prompt: prompt.map(str::to_string),
             },
             check: DoctorGroupActionCheck {
                 command: check_command.map(DoctorGroupActionCommand::from),
@@ -202,12 +202,6 @@ fn parse_action(
     } else {
         None
     };
-    let autofix = if let Some(fix) = &spec_action.fix {
-        fix.autofix
-    } else {
-        // FIXME: I don't like this we should only need to know autofix if there is a fix at all
-        true
-    };
 
     let check_command = if let Some(ref check) = spec_action.check.commands {
         let mut templated_commands = Vec::new();
@@ -230,7 +224,7 @@ fn parse_action(
             .unwrap_or_else(|| "default".to_string()),
         fix: DoctorGroupActionFix {
             command: fix_command,
-            autofix,
+            prompt: spec_action.fix.and_then(|fix| fix.prompt),
             help_text,
             help_url,
         },
@@ -286,7 +280,7 @@ mod tests {
                     command: Some(DoctorGroupActionCommand::from(vec![
                         "/foo/bar/.scope/fix1.sh"
                     ])),
-                    autofix: true,
+                    prompt: None,
                     help_text: Some("There is a good way to fix this, maybe...".to_string()),
                     help_url: Some("https://go.example.com/fixit".to_string()),
                 },
@@ -311,7 +305,7 @@ mod tests {
                     command: None,
                     help_text: None,
                     help_url: None,
-                    autofix: true,
+                    prompt: None,
                 },
                 check: DoctorGroupActionCheck {
                     command: Some(DoctorGroupActionCommand::from(vec!["sleep infinity"])),

--- a/scope/src/shared/models/internal/doctor_group.rs
+++ b/scope/src/shared/models/internal/doctor_group.rs
@@ -29,12 +29,15 @@ pub struct DoctorGroupActionFix {
     pub help_text: Option<String>,
     #[builder(default)]
     pub help_url: Option<String>,
+    #[builder(default)]
+    pub autofix: bool,
 }
 
 impl DoctorGroupAction {
     pub fn make_from(
         name: &str,
         description: &str,
+        autofix: bool,
         fix_command: Option<Vec<&str>>,
         check_path: Option<(&str, Vec<&str>)>,
         check_command: Option<Vec<&str>>,
@@ -47,6 +50,7 @@ impl DoctorGroupAction {
                 command: fix_command.map(DoctorGroupActionCommand::from),
                 help_text: None,
                 help_url: None,
+                autofix,
             },
             check: DoctorGroupActionCheck {
                 command: check_command.map(DoctorGroupActionCommand::from),
@@ -198,6 +202,12 @@ fn parse_action(
     } else {
         None
     };
+    let autofix = if let Some(fix) = &spec_action.fix {
+        fix.autofix
+    } else {
+        // FIXME: I don't like this we should only need to know autofix if there is a fix at all
+        true
+    };
 
     let check_command = if let Some(ref check) = spec_action.check.commands {
         let mut templated_commands = Vec::new();
@@ -220,6 +230,7 @@ fn parse_action(
             .unwrap_or_else(|| "default".to_string()),
         fix: DoctorGroupActionFix {
             command: fix_command,
+            autofix,
             help_text,
             help_url,
         },
@@ -275,6 +286,7 @@ mod tests {
                     command: Some(DoctorGroupActionCommand::from(vec![
                         "/foo/bar/.scope/fix1.sh"
                     ])),
+                    autofix: true,
                     help_text: Some("There is a good way to fix this, maybe...".to_string()),
                     help_url: Some("https://go.example.com/fixit".to_string()),
                 },
@@ -299,6 +311,7 @@ mod tests {
                     command: None,
                     help_text: None,
                     help_url: None,
+                    autofix: true,
                 },
                 check: DoctorGroupActionCheck {
                     command: Some(DoctorGroupActionCommand::from(vec!["sleep infinity"])),

--- a/scope/src/shared/models/internal/doctor_group.rs
+++ b/scope/src/shared/models/internal/doctor_group.rs
@@ -30,14 +30,23 @@ pub struct DoctorGroupActionFix {
     #[builder(default)]
     pub help_url: Option<String>,
     #[builder(default)]
-    pub prompt: Option<String>,
+    pub prompt: Option<DoctorGroupActionFixPrompt>,
+}
+
+#[derive(Debug, PartialEq, Clone, Builder)]
+#[builder(setter(into))]
+pub struct DoctorGroupActionFixPrompt {
+    #[builder(default)]
+    pub text: String,
+    #[builder(default)]
+    pub extra_context: Option<String>,
 }
 
 impl DoctorGroupAction {
     pub fn make_from(
         name: &str,
         description: &str,
-        prompt: Option<&str>,
+        prompt: Option<DoctorGroupActionFixPrompt>,
         fix_command: Option<Vec<&str>>,
         check_path: Option<(&str, Vec<&str>)>,
         check_command: Option<Vec<&str>>,
@@ -50,7 +59,7 @@ impl DoctorGroupAction {
                 command: fix_command.map(DoctorGroupActionCommand::from),
                 help_text: None,
                 help_url: None,
-                prompt: prompt.map(str::to_string),
+                prompt,
             },
             check: DoctorGroupActionCheck {
                 command: check_command.map(DoctorGroupActionCommand::from),
@@ -224,7 +233,12 @@ fn parse_action(
             .unwrap_or_else(|| "default".to_string()),
         fix: DoctorGroupActionFix {
             command: fix_command,
-            prompt: spec_action.fix.and_then(|fix| fix.prompt),
+            prompt: spec_action.fix.and_then(|fix| fix.prompt).map(|p| {
+                DoctorGroupActionFixPrompt {
+                    text: p.text,
+                    extra_context: p.extra_context,
+                }
+            }),
             help_text,
             help_url,
         },


### PR DESCRIPTION
Use Case
---
We have some fixes that we don't want to apply without user approval because there will be data loss, e.g. `rails db:reset`.

Solution
---
Extend the current `ScopeDoctorGroup.spec.fix` element to allow users to specify that a fix shouldn't be applied without user approval.

```yaml
      fix:
        prompt:
          text: |-
            This may destroy some data.
            Do you wish to continue?
          # this is an optional field
          helpText: >-
            Some additional context about why this needs approval
            and what it's actually doing
```

Current implementation achieves this by adding a nullable `prompt` property to the schema.
When it's unset, we get the current behavior, so this is backward compatible.

Example can be seen by checking out this branch and running

```sh
cargo run -- doctor run --working-dir examples --only prompt
```

https://github.com/user-attachments/assets/42509a95-b1b8-4579-a6ff-646787ed91bb

This PR depends on #183 which fixed some issues with the summary calculation.