### PR TITLE
Add verify: false option to doctor group action fixes.

### DIFF
--- a/examples/.scope/doctor-group-no-verify.yaml
+++ b/examples/.scope/doctor-group-no-verify.yaml
@@ -1,0 +1,24 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: no-verify
+  description: |
+    Sometimes we may want to trigger a fix when a file changes, 
+    and _also_ some other condition, but there that condition won't
+    change after the fix.
+    Setting `verify: false` skips running the check commands after the fix has run.
+spec:
+  include: when-required
+  actions:
+    - name: no-verify
+      verify: false
+      check:
+        paths:
+          - example.txt
+        commands:
+          # Maybe you have a script that also checks the value of an env variable.
+          # Here, we'll just run the `false` command so it always fails.
+          - "false"
+      fix:
+        commands:
+          - echo "The fix ran, but the check command still fails. That's okay because verify is set to false."

--- a/scope/schema/merged.json
+++ b/scope/schema/merged.json
@@ -153,6 +153,11 @@
           "description": "If false, the action is allowed to fail and let other actions in the group execute. Defaults to `true`.",
           "default": true,
           "type": "boolean"
+        },
+        "verify": {
+          "description": "If false, the check does not run again after the fix. Defaults to `true`.",
+          "default": true,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -169,6 +169,11 @@
           "description": "If false, the action is allowed to fail and let other actions in the group execute. Defaults to `true`.",
           "default": true,
           "type": "boolean"
+        },
+        "verify": {
+          "description": "If false, the check does not run again after the fix. Defaults to `true`.",
+          "default": true,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -169,6 +169,11 @@
           "description": "If false, the action is allowed to fail and let other actions in the group execute. Defaults to `true`.",
           "default": true,
           "type": "boolean"
+        },
+        "verify": {
+          "description": "If false, the check does not run again after the fix. Defaults to `true`.",
+          "default": true,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -169,6 +169,11 @@
           "description": "If false, the action is allowed to fail and let other actions in the group execute. Defaults to `true`.",
           "default": true,
           "type": "boolean"
+        },
+        "verify": {
+          "description": "If false, the check does not run again after the fix. Defaults to `true`.",
+          "default": true,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -251,7 +251,8 @@ where
             results.status = match action_result.status {
                 ActionRunStatus::CheckSucceeded
                 | ActionRunStatus::NoCheckFixSucceeded
-                | ActionRunStatus::CheckFailedFixSucceedVerifySucceed => {
+                | ActionRunStatus::CheckFailedFixSucceedVerifySucceed
+                | ActionRunStatus::CheckFailedFixSucceededNoVerification => {
                     GroupExecutionStatus::Succeeded
                 }
                 ActionRunStatus::CheckFailedFixUserDenied => GroupExecutionStatus::Skipped,
@@ -320,6 +321,12 @@ where
         }
         ActionRunStatus::CheckFailedFixSucceedVerifyFailed => {
             error!(target: "user", group = group_name, name = action.name(), "Check initially failed, fix ran, verification {}", "failed".red().bold());
+            print_pretty_result(group_name, &action.name(), action_result)
+                .await
+                .ok();
+        }
+        ActionRunStatus::CheckFailedFixSucceededNoVerification => {
+            info!(target: "user", group = group_name, name = action.name(), "Checked failed, fix succeeded, no verification");
             print_pretty_result(group_name, &action.name(), action_result)
                 .await
                 .ok();

--- a/scope/src/models/v1alpha/doctor_group.rs
+++ b/scope/src/models/v1alpha/doctor_group.rs
@@ -89,9 +89,17 @@ pub struct DoctorGroupActionSpec {
     /// to `true`.
     #[serde(default = "doctor_group_action_required_default")]
     pub required: bool,
+
+    /// If false, the check does not run again after the fix. Defaults to `true`.
+    #[serde(default = "doctor_group_action_verify_default")]
+    pub verify: bool,
 }
 
 fn doctor_group_action_required_default() -> bool {
+    true
+}
+
+fn doctor_group_action_verify_default() -> bool {
     true
 }
 

--- a/scope/src/shared/models/internal/doctor_group.rs
+++ b/scope/src/shared/models/internal/doctor_group.rs
@@ -18,6 +18,7 @@ pub struct DoctorGroupAction {
     pub fix: DoctorGroupActionFix,
     pub check: DoctorGroupActionCheck,
     pub required: bool,
+    pub verify: bool,
 }
 
 #[derive(Debug, PartialEq, Clone, Builder)]
@@ -40,36 +41,6 @@ pub struct DoctorGroupActionFixPrompt {
     pub text: String,
     #[builder(default)]
     pub extra_context: Option<String>,
-}
-
-impl DoctorGroupAction {
-    pub fn make_from(
-        name: &str,
-        description: &str,
-        prompt: Option<DoctorGroupActionFixPrompt>,
-        fix_command: Option<Vec<&str>>,
-        check_path: Option<(&str, Vec<&str>)>,
-        check_command: Option<Vec<&str>>,
-    ) -> Self {
-        Self {
-            required: true,
-            name: name.to_string(),
-            description: description.to_string(),
-            fix: DoctorGroupActionFix {
-                command: fix_command.map(DoctorGroupActionCommand::from),
-                help_text: None,
-                help_url: None,
-                prompt,
-            },
-            check: DoctorGroupActionCheck {
-                command: check_command.map(DoctorGroupActionCommand::from),
-                files: check_path.map(|(base, paths)| DoctorGroupCachePath {
-                    base_path: PathBuf::from(base),
-                    paths: crate::shared::convert_to_string(paths),
-                }),
-            },
-        }
-    }
 }
 
 #[derive(Debug, PartialEq, Clone, Builder)]
@@ -228,6 +199,7 @@ fn parse_action(
     Ok(DoctorGroupAction {
         name: spec_action.name.unwrap_or_else(|| format!("{}", idx + 1)),
         required: spec_action.required,
+        verify: spec_action.verify,
         description: spec_action
             .description
             .unwrap_or_else(|| "default".to_string()),
@@ -289,6 +261,7 @@ mod tests {
             DoctorGroupAction {
                 name: "1".to_string(),
                 required: false,
+                verify: true,
                 description: "foo1".to_string(),
                 fix: DoctorGroupActionFix {
                     command: Some(DoctorGroupActionCommand::from(vec![
@@ -314,6 +287,7 @@ mod tests {
             DoctorGroupAction {
                 name: "2".to_string(),
                 required: true,
+                verify: true,
                 description: "foo2".to_string(),
                 fix: DoctorGroupActionFix {
                     command: None,


### PR DESCRIPTION
Sometimes you may want to trigger a fix based on a file change as well as some other condition, like the value of an environment variable, but the fix does not change the condition.

Or, perhaps there isn't a good (or fast maybe) way to check that things are ok, so you want the fix to run whenever `--no-cache` is passed.

Currently, the check always runs after the fix to verify that the fix worked. This commit introduces a way to skip running the check a second time as verification. This functionality should only really be used as a last resort option, but it should be possible for the small set of edge cases where it's needed.

To see it in action:
```sh
cargo run -- doctor run --working-dir examples --only=no-verify --progress=plain
```