### PR TITLE
Extract and rename Fix and Command

### DIFF
--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -7,8 +7,8 @@ use std::collections::BTreeMap;
 use crate::models::HelpMetadata;
 use crate::prelude::{ActionReport, ActionReportBuilder, ActionTaskReport};
 use crate::shared::prelude::{
-    CaptureError, CaptureOpts, DoctorGroup, DoctorGroupAction, DoctorGroupActionCommand,
-    DoctorGroupCachePath, ExecutionProvider, OutputDestination,
+    CaptureError, CaptureOpts, DoctorCommand, DoctorGroup, DoctorGroupAction, DoctorGroupCachePath,
+    ExecutionProvider, OutputDestination,
 };
 use async_trait::async_trait;
 use derive_builder::Builder;
@@ -460,7 +460,7 @@ impl DefaultDoctorActionRun {
 
     async fn run_check_command(
         &self,
-        action_command: &DoctorGroupActionCommand,
+        action_command: &DoctorCommand,
     ) -> Result<CacheResults, RuntimeError> {
         info!("Evaluating {:?}", action_command);
         let mut action_reports = Vec::new();
@@ -663,13 +663,13 @@ pub(crate) mod tests {
             .check(
                 DoctorGroupActionCheckBuilder::default()
                     .files(None)
-                    .command(Some(DoctorGroupActionCommand::from(vec!["check"])))
+                    .command(Some(DoctorCommand::from(vec!["check"])))
                     .build()
                     .unwrap(),
             )
             .fix(
-                DoctorGroupActionFixBuilder::default()
-                    .command(Some(DoctorGroupActionCommand::from(vec!["fix"])))
+                DoctorFixBuilder::default()
+                    .command(Some(DoctorCommand::from(vec!["fix"])))
                     .build()
                     .unwrap(),
             )
@@ -685,13 +685,13 @@ pub(crate) mod tests {
             .check(
                 DoctorGroupActionCheckBuilder::default()
                     .files(None)
-                    .command(Some(DoctorGroupActionCommand::from(vec!["check"])))
+                    .command(Some(DoctorCommand::from(vec!["check"])))
                     .build()
                     .unwrap(),
             )
             .fix(
-                DoctorGroupActionFixBuilder::default()
-                    .command(Some(DoctorGroupActionCommand::from(vec!["fix"])))
+                DoctorFixBuilder::default()
+                    .command(Some(DoctorCommand::from(vec!["fix"])))
                     .prompt(Some(DoctorGroupActionFixPrompt {
                         text: "do you want to continue?".to_string(),
                         extra_context: Some("additional context here".to_string()),
@@ -716,8 +716,8 @@ pub(crate) mod tests {
                     .unwrap(),
             )
             .fix(
-                DoctorGroupActionFixBuilder::default()
-                    .command(Some(DoctorGroupActionCommand::from(vec!["fix"])))
+                DoctorFixBuilder::default()
+                    .command(Some(DoctorCommand::from(vec!["fix"])))
                     .build()
                     .unwrap(),
             )
@@ -1201,7 +1201,7 @@ pub(crate) mod tests {
                 MockGlobWalker::new(),
             );
 
-            let action_commands = DoctorGroupActionCommandBuilder::default()
+            let action_commands = DoctorCommandBuilder::default()
                 .commands(vec!["test -f ~/.somefile".to_string()])
                 .build()
                 .unwrap();

--- a/scope/src/shared/models/internal/command.rs
+++ b/scope/src/shared/models/internal/command.rs
@@ -1,0 +1,77 @@
+use std::path::Path;
+
+use derive_builder::Builder;
+
+use super::extract_command_path;
+
+#[derive(Debug, PartialEq, Clone, Builder)]
+#[builder(setter(into))]
+pub struct DoctorCommand {
+    pub commands: Vec<String>,
+}
+
+impl<T> From<(&Path, Vec<T>)> for DoctorCommand
+where
+    String: for<'a> From<&'a T>,
+{
+    fn from((base_path, command_strings): (&Path, Vec<T>)) -> Self {
+        let commands = command_strings
+            .iter()
+            .map(|s| {
+                let exec: String = s.into();
+                extract_command_path(base_path, &exec)
+            })
+            .collect();
+
+        DoctorCommand { commands }
+    }
+}
+
+#[cfg(test)]
+impl From<Vec<&str>> for DoctorCommand {
+    /// This is only used by some tests and should NOT be used in production code
+    /// because it does not properly pre-pend the command with a base path.
+    fn from(value: Vec<&str>) -> Self {
+        let commands = value.iter().map(|x| x.to_string()).collect();
+        Self { commands }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_vec_str() {
+        let input = vec!["echo 'foo'", "false"];
+
+        let actual = DoctorCommand::from(input.clone());
+
+        assert_eq!(
+            DoctorCommand {
+                commands: vec![input[0].to_string(), input[1].to_string(),]
+            },
+            actual
+        )
+    }
+
+    #[test]
+    fn from_path_and_vec_string() {
+        let base_path = Path::new("/foo/bar");
+        let input = vec!["echo 'foo'", "baz/qux", "./qux"];
+
+        let actual =
+            DoctorCommand::from((base_path, input.iter().map(|cmd| cmd.to_string()).collect()));
+
+        assert_eq!(
+            DoctorCommand {
+                commands: vec![
+                    "echo 'foo'".to_string(),
+                    "baz/qux".to_string(),
+                    "/foo/bar/qux".to_string(),
+                ]
+            },
+            actual
+        )
+    }
+}

--- a/scope/src/shared/models/internal/fix.rs
+++ b/scope/src/shared/models/internal/fix.rs
@@ -1,0 +1,27 @@
+use crate::shared::prelude::*;
+use derive_builder::Builder;
+
+#[derive(Debug, PartialEq, Clone, Builder)]
+#[builder(setter(into))]
+pub struct DoctorFix {
+    #[builder(default)]
+    pub command: Option<DoctorCommand>,
+    #[builder(default)]
+    pub help_text: Option<String>,
+    #[builder(default)]
+    pub help_url: Option<String>,
+    #[builder(default)]
+    pub prompt: Option<DoctorGroupActionFixPrompt>,
+}
+
+#[derive(Debug, PartialEq, Clone, Builder)]
+#[builder(setter(into))]
+pub struct DoctorGroupActionFixPrompt {
+    #[builder(default)]
+    pub text: String,
+    #[builder(default)]
+    pub extra_context: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {}

--- a/scope/src/shared/models/internal/mod.rs
+++ b/scope/src/shared/models/internal/mod.rs
@@ -9,7 +9,9 @@ use serde_yaml::Value;
 use std::collections::VecDeque;
 use std::path::Path;
 
+mod command;
 mod doctor_group;
+mod fix;
 mod known_error;
 mod upload_location;
 
@@ -18,7 +20,7 @@ use self::upload_location::ReportUploadLocation;
 
 pub mod prelude {
     pub use super::ParsedConfig;
-    pub use super::{doctor_group::*, known_error::*, upload_location::*};
+    pub use super::{command::*, doctor_group::*, fix::*, known_error::*, upload_location::*};
 }
 
 #[derive(Debug, PartialEq)]
@@ -89,17 +91,22 @@ pub(crate) fn extract_command_path(parent_dir: &Path, exec: &str) -> String {
         .join(" ")
 }
 
-#[test]
-fn test_extract_command_path() {
-    let base_path = Path::new("/foo/bar");
-    assert_eq!(
-        "/foo/bar/scripts/foo.sh",
-        extract_command_path(base_path, "./scripts/foo.sh")
-    );
-    assert_eq!(
-        "/scripts/foo.sh",
-        extract_command_path(base_path, "/scripts/foo.sh")
-    );
-    assert_eq!("foo", extract_command_path(base_path, "foo"));
-    assert_eq!("foo bar", extract_command_path(base_path, "foo bar"));
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_command_path() {
+        let base_path = Path::new("/foo/bar");
+        assert_eq!(
+            "/foo/bar/scripts/foo.sh",
+            extract_command_path(base_path, "./scripts/foo.sh")
+        );
+        assert_eq!(
+            "/scripts/foo.sh",
+            extract_command_path(base_path, "/scripts/foo.sh")
+        );
+        assert_eq!("foo", extract_command_path(base_path, "foo"));
+        assert_eq!("foo bar", extract_command_path(base_path, "foo bar"));
+    }
 }


### PR DESCRIPTION
These internal models can be reused for #160 (fixes for known errors), so they will no longer be specific to ScopeDoctorGroup

I also wrapped a test in `#[cfg(test)]` so it no longer gets compiled into the production binary.