### PR TITLE
Fixes for Known Errors

### DIFF
--- a/examples/.scope/doctor-group-fail.yaml
+++ b/examples/.scope/doctor-group-fail.yaml
@@ -14,5 +14,6 @@ spec:
           - echo "found file {{ working_dir }}/file-mod.txt"
           - test -f {{ working_dir }}/file-mod.txt
       fix:
+        helpText: "This displays when the fix fails"
         commands:
           - echo {{ working_dir }}/file-mod.txt

--- a/examples/.scope/known-error-with-fix.yaml
+++ b/examples/.scope/known-error-with-fix.yaml
@@ -9,18 +9,15 @@ spec:
   fix:
     commands:
       - echo 'Running some thing that will fix the error we found.'
-    # Stuff below here is part of the ScopeDoctorFix model
-    # I'd like them to be the same, but maybe that's not best.
-    # For example, I'm unsure if an extra prompt is wise given we're already going to prompt
-    # for approval before running he fix.
-    #
-    # helpText: This text displays when the commands fail.
-    # helpUrl: https://example.com
-    # prompt:
-    #   text: |-
-    #     This may destroy some data.
-    #     Do you wish to continue?
-    #   # this is an optional field
-    #   extraContext: >-
-    #     Some additional context about why this needs approval
-    #     and what it's actually doing
+      # uncomment to test helpText and helpUrl
+      # - 'false'
+    helpText: This text displays when the fix fails.
+    helpUrl: https://example.com
+    prompt:
+      text: |-
+        This may destroy some data.
+        Do you wish to continue?
+      # this is an optional field
+      extraContext: >-
+        Some additional context about why this needs approval
+        and what it's actually doing

--- a/examples/.scope/known-error-with-fix.yaml
+++ b/examples/.scope/known-error-with-fix.yaml
@@ -1,0 +1,26 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeKnownError
+metadata:
+  name: known-error-with-fix
+  description: Check if the word kaboom is in the logs
+spec:
+  pattern: kaboom
+  help: The command had an error, try reading the logs around there to find out what happened.
+  fix:
+    commands:
+      - echo 'Running some thing that will fix the error we found.'
+    # Stuff below here is part of the ScopeDoctorFix model
+    # I'd like them to be the same, but maybe that's not best.
+    # For example, I'm unsure if an extra prompt is wise given we're already going to prompt
+    # for approval before running he fix.
+    #
+    # helpText: This text displays when the commands fail.
+    # helpUrl: https://example.com
+    # prompt:
+    #   text: |-
+    #     This may destroy some data.
+    #     Do you wish to continue?
+    #   # this is an optional field
+    #   extraContext: >-
+    #     Some additional context about why this needs approval
+    #     and what it's actually doing

--- a/scope/schema/merged.json
+++ b/scope/schema/merged.json
@@ -234,6 +234,18 @@
         "pattern"
       ],
       "properties": {
+        "fix": {
+          "description": "An optional fix the user will be prompted to run.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DoctorFixSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "nullable": true
+        },
         "help": {
           "description": "Text that the user can use to fix the issue",
           "type": "string"

--- a/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -250,6 +250,18 @@
         "pattern"
       ],
       "properties": {
+        "fix": {
+          "description": "An optional fix the user will be prompted to run.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DoctorFixSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "nullable": true
+        },
         "help": {
           "description": "Text that the user can use to fix the issue",
           "type": "string"

--- a/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -250,6 +250,18 @@
         "pattern"
       ],
       "properties": {
+        "fix": {
+          "description": "An optional fix the user will be prompted to run.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DoctorFixSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "nullable": true
+        },
         "help": {
           "description": "Text that the user can use to fix the issue",
           "type": "string"

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -250,6 +250,18 @@
         "pattern"
       ],
       "properties": {
+        "fix": {
+          "description": "An optional fix the user will be prompted to run.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/DoctorFixSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "nullable": true
+        },
         "help": {
           "description": "Text that the user can use to fix the issue",
           "type": "string"

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -2,10 +2,9 @@ use super::file_cache::{FileCache, FileCacheStatus};
 use anyhow::Result;
 use std::cmp;
 use std::cmp::max;
-use std::collections::BTreeMap;
 
 use crate::models::HelpMetadata;
-use crate::prelude::{ActionReport, ActionReportBuilder, ActionTaskReport};
+use crate::prelude::{generate_env_vars, ActionReport, ActionReportBuilder, ActionTaskReport};
 use crate::shared::prelude::{
     CaptureError, CaptureOpts, DoctorCommand, DoctorGroup, DoctorGroupAction, DoctorGroupCachePath,
     ExecutionProvider, OutputDestination,
@@ -317,10 +316,10 @@ impl DefaultDoctorActionRun {
         match &self.action.fix.command {
             None => Ok((NO_COMMANDS_EXIT_CODE, Vec::new())),
             Some(action_command) => match &self.action.fix.prompt {
-                None => Ok(self.run_commands(&action_command.commands).await?),
+                None => Ok(self.run_commands(&action_command).await?),
                 Some(fix_prompt) => {
                     if prompt(&fix_prompt.text, &fix_prompt.extra_context) {
-                        Ok(self.run_commands(&action_command.commands).await?)
+                        Ok(self.run_commands(&action_command).await?)
                     } else {
                         Ok((USER_DENIED_EXIT_CODE, Vec::new()))
                     }
@@ -331,13 +330,13 @@ impl DefaultDoctorActionRun {
 
     async fn run_commands(
         &self,
-        commands: &Vec<String>,
+        commands: &DoctorCommand,
     ) -> Result<(i32, Vec<ActionTaskReport>), RuntimeError> {
         let mut action_reports = Vec::new();
         let mut highest_exit_code = NO_COMMANDS_EXIT_CODE;
 
-        for command in commands {
-            let report = self.run_single_fix(command).await?;
+        for command in commands.expand() {
+            let report = self.run_single_fix(&command).await?;
             highest_exit_code = max(
                 highest_exit_code,
                 report.exit_code.unwrap_or(NO_COMMANDS_EXIT_CODE),
@@ -352,7 +351,7 @@ impl DefaultDoctorActionRun {
     }
 
     async fn run_single_fix(&self, command: &str) -> Result<ActionTaskReport, RuntimeError> {
-        let args = vec![Self::expand_command(command)];
+        let args = vec![command.to_string()];
         let capture = self
             .exec_runner
             .run_command(CaptureOpts {
@@ -364,28 +363,13 @@ impl DefaultDoctorActionRun {
                     self.action.name
                 )),
                 path: &self.model.metadata.exec_path(),
-                env_vars: self.generate_env_vars(),
+                env_vars: generate_env_vars(),
             })
             .await?;
 
         info!("fix ran {} and exited {:?}", command, capture.exit_code);
 
         Ok(ActionTaskReport::from(&capture))
-    }
-
-    fn generate_env_vars(&self) -> BTreeMap<String, String> {
-        let mut env_vars = BTreeMap::new();
-        env_vars.insert(
-            "SCOPE_BIN_DIR".to_string(),
-            std::env::current_exe()
-                .unwrap()
-                .parent()
-                .expect("executable should be in a directory")
-                .to_str()
-                .expect("bin directory should be a valid string")
-                .to_string(),
-        );
-        env_vars
     }
 
     async fn evaluate_checks(&self) -> Result<CacheResults, RuntimeError> {
@@ -466,8 +450,8 @@ impl DefaultDoctorActionRun {
         let mut action_reports = Vec::new();
         let mut result: Option<CacheStatus> = None;
 
-        for command in &action_command.commands {
-            let args = vec![Self::expand_command(command)];
+        for command in &action_command.expand() {
+            let args = vec![command.clone()];
             let path = format!(
                 "{}:{}",
                 self.model.metadata().containing_dir(),
@@ -480,7 +464,7 @@ impl DefaultDoctorActionRun {
                     args: &args,
                     output_dest: OutputDestination::Logging,
                     path: &path,
-                    env_vars: self.generate_env_vars(),
+                    env_vars: generate_env_vars(),
                 })
                 .await?;
 
@@ -513,16 +497,6 @@ impl DefaultDoctorActionRun {
             status,
             output: Some(action_reports),
         })
-    }
-
-    /// splits a commands and performs shell expansion its parts
-    fn expand_command(command: &str) -> String {
-        command
-            .split(' ')
-            //consider doing a full expansion that includes env vars?
-            .map(|word| shellexpand::tilde(word))
-            .collect::<Vec<_>>()
-            .join(" ")
     }
 }
 
@@ -1146,7 +1120,7 @@ pub(crate) mod tests {
         assert!(res.is_ok());
     }
 
-    mod test_run_single_fix {
+    mod test_run_commands {
         use super::*;
 
         #[tokio::test]
@@ -1169,11 +1143,18 @@ pub(crate) mod tests {
                 MockGlobWalker::new(),
             );
 
-            let result = run.run_single_fix("touch ~/.somefile").await.unwrap();
+            let (_highest_status_code, reports) = run
+                .run_commands(&DoctorCommand {
+                    commands: vec!["touch ~/.somefile".to_string()],
+                })
+                .await
+                .unwrap();
+            let report = reports[0].clone();
+            let actual_command = report.command;
 
             assert_eq!(
                 format!("{} {}", "touch", home_dir().join(".somefile").display()),
-                result.command
+                actual_command
             );
         }
     }

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -316,10 +316,10 @@ impl DefaultDoctorActionRun {
         match &self.action.fix.command {
             None => Ok((NO_COMMANDS_EXIT_CODE, Vec::new())),
             Some(action_command) => match &self.action.fix.prompt {
-                None => Ok(self.run_commands(&action_command).await?),
+                None => Ok(self.run_commands(action_command).await?),
                 Some(fix_prompt) => {
                     if prompt(&fix_prompt.text, &fix_prompt.extra_context) {
-                        Ok(self.run_commands(&action_command).await?)
+                        Ok(self.run_commands(action_command).await?)
                     } else {
                         Ok((USER_DENIED_EXIT_CODE, Vec::new()))
                     }

--- a/scope/src/models/v1alpha/known_error.rs
+++ b/scope/src/models/v1alpha/known_error.rs
@@ -5,6 +5,8 @@ use derive_builder::Builder;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::prelude::DoctorFixSpec;
+
 /// Definition of the known error
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -15,6 +17,9 @@ pub struct KnownErrorSpec {
 
     /// A Regex used to determine if the line is an error.
     pub pattern: String,
+
+    /// An optional fix the user will be prompted to run.
+    pub fix: Option<DoctorFixSpec>,
 }
 
 #[derive(Serialize, Deserialize, Debug, strum::Display, Clone, PartialEq, JsonSchema)]

--- a/scope/src/models/v1alpha/mod.rs
+++ b/scope/src/models/v1alpha/mod.rs
@@ -21,4 +21,5 @@ pub mod prelude {
     pub use super::doctor_group::*;
     pub use super::known_error::*;
     pub use super::report_location::*;
+    pub use super::V1AlphaApiVersion;
 }

--- a/scope/src/shared/models/internal/command.rs
+++ b/scope/src/shared/models/internal/command.rs
@@ -22,6 +22,24 @@ impl DoctorCommand {
         }
         Ok(DoctorCommand::from((containing_dir, templated_commands)))
     }
+
+    /// Performs shell expansion
+    pub fn expand(&self) -> Vec<String> {
+        self.commands
+            .iter()
+            .map(|cmd| Self::expand_command(cmd))
+            .collect()
+    }
+
+    /// splits a commands and performs shell expansion its parts
+    fn expand_command(command: &str) -> String {
+        command
+            .split(' ')
+            //consider doing a full expansion that includes env vars?
+            .map(|word| shellexpand::tilde(word))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
 }
 
 impl<T> From<(&Path, Vec<T>)> for DoctorCommand

--- a/scope/src/shared/models/internal/known_error.rs
+++ b/scope/src/shared/models/internal/known_error.rs
@@ -1,7 +1,11 @@
+use std::path::Path;
+
 use crate::models::prelude::{ModelMetadata, V1AlphaKnownError};
 use crate::models::HelpMetadata;
 use derivative::Derivative;
 use regex::Regex;
+
+use super::fix::DoctorFix;
 
 #[derive(Derivative)]
 #[derivative(PartialEq)]
@@ -13,6 +17,7 @@ pub struct KnownError {
     #[derivative(PartialEq = "ignore")]
     pub regex: Regex,
     pub help_text: String,
+    pub fix: Option<DoctorFix>,
 }
 
 impl HelpMetadata for KnownError {
@@ -30,20 +35,47 @@ impl TryFrom<V1AlphaKnownError> for KnownError {
 
     fn try_from(value: V1AlphaKnownError) -> Result<Self, Self::Error> {
         let regex = Regex::new(&value.spec.pattern)?;
+
+        let binding = value.metadata.containing_dir();
+        let containing_dir = Path::new(&binding);
+        let working_dir = value
+            .metadata
+            .annotations
+            .working_dir
+            .as_ref()
+            .unwrap()
+            .clone();
+
+        let maybe_fix = match value.spec.fix {
+            Some(ref fix) => Some(DoctorFix::from_spec(
+                containing_dir,
+                &working_dir,
+                fix.clone(),
+            )?),
+            None => None,
+        };
+
         Ok(KnownError {
             full_name: value.full_name(),
             metadata: value.metadata,
             pattern: value.spec.pattern,
             regex,
             help_text: value.spec.help,
+            fix: maybe_fix,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::prelude::{
+        DoctorFixSpec, KnownErrorKind, KnownErrorSpec, ModelMetadataAnnotations, V1AlphaApiVersion,
+        V1AlphaKnownError,
+    };
     use crate::shared::models::parse_models_from_string;
 
+    use std::collections::BTreeMap;
     use std::path::Path;
 
     #[test]
@@ -67,5 +99,58 @@ spec:
         assert_eq!("ScopeKnownError/error-exists", model.full_name);
         assert_eq!("The command had an error, try reading the logs around there to find out what happened.", model.help_text);
         assert_eq!("error", model.pattern);
+    }
+
+    #[test]
+    fn try_from_spec() {
+        let model_metadata = ModelMetadata {
+            name: "some test error".to_string(),
+            description: "some description".to_string(),
+            annotations: ModelMetadataAnnotations {
+                file_path: Some("/foo/bar/file.yaml".to_string()),
+                file_dir: Some("/foo/bar".to_string()),
+                working_dir: Some("/some/work/dir".to_string()),
+                bin_path: None,
+                extra: BTreeMap::new(),
+            },
+            labels: BTreeMap::new(),
+        };
+
+        let input = V1AlphaKnownError {
+            api_version: V1AlphaApiVersion::ScopeV1Alpha,
+            kind: KnownErrorKind::ScopeKnownError,
+            metadata: model_metadata.clone(),
+            spec: KnownErrorSpec {
+                help: "some help text".to_string(),
+                pattern: "some regex pattern".to_string(),
+                fix: Some(DoctorFixSpec {
+                    commands: vec!["echo 'fix it!'".to_string()],
+                    help_text: None,
+                    help_url: None,
+                    prompt: None,
+                }),
+            },
+        };
+
+        let actual = KnownError::try_from(input.clone()).unwrap();
+
+        assert_eq!(
+            KnownError {
+                full_name: "ScopeKnownError/some test error".to_string(),
+                metadata: input.metadata,
+                pattern: input.spec.pattern.clone(),
+                regex: Regex::new(&input.spec.pattern).unwrap(),
+                help_text: input.spec.help,
+                fix: Some(
+                    DoctorFix::from_spec(
+                        Path::new(&model_metadata.containing_dir()),
+                        &model_metadata.annotations.working_dir.unwrap(),
+                        input.spec.fix.unwrap()
+                    )
+                    .unwrap()
+                ),
+            },
+            actual
+        )
     }
 }

--- a/scope/src/shared/models/internal/mod.rs
+++ b/scope/src/shared/models/internal/mod.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use minijinja::{context, Environment};
 use path_clean::PathClean;
 use serde_yaml::Value;
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, VecDeque};
 use std::path::Path;
 
 mod command;
@@ -21,6 +21,7 @@ use self::known_error::KnownError;
 use self::upload_location::ReportUploadLocation;
 
 pub mod prelude {
+    pub use super::generate_env_vars;
     pub use super::ParsedConfig;
     pub use super::{command::*, doctor_group::*, fix::*, known_error::*, upload_location::*};
 }
@@ -100,6 +101,21 @@ pub(crate) fn substitute_templates(work_dir: &str, input_str: &str) -> Result<St
     let result = template.render(context! { working_dir => work_dir })?;
 
     Ok(result)
+}
+
+pub fn generate_env_vars() -> BTreeMap<String, String> {
+    let mut env_vars = BTreeMap::new();
+    env_vars.insert(
+        "SCOPE_BIN_DIR".to_string(),
+        std::env::current_exe()
+            .unwrap()
+            .parent()
+            .expect("executable should be in a directory")
+            .to_str()
+            .expect("bin directory should be a valid string")
+            .to_string(),
+    );
+    env_vars
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Implementation for #160 

```console
❯ cargo run -- analyze command --working-dir examples -- echo 'kaboom'
analyzing:  kaboom
 WARN Known error 'known-error-with-fix' found on line 0
 INFO   ==> The command had an error, try reading the logs around there to find out what happened.
 INFO found a fix!
> Would you like to run it? Yes
fixing:  Running some thing that will fix the error we found.
 INFO Fix succeeded
```


```console
❯ cargo run -- analyze command --working-dir examples -- echo 'error'
analyzing:  error
 WARN Known error 'error-exists' found on line 0
 INFO   ==> The command had an error, try reading the logs around there to find out what happened.
 INFO No automatic fix available
```


Uncomment out the `false` command to test failure mode

```console
❯ cargo run -- analyze command --working-dir examples -- echo 'kaboom'
analyzing:  kaboom
 WARN Known error 'known-error-with-fix' found on line 0
 INFO   ==> The command had an error, try reading the logs around there to find out what happened.
 INFO found a fix!
> This may destroy some data.
Do you wish to continue? Yes
ERROR Fix Help: This text displays when the fix fails.
ERROR For more help, please visit https://example.com
ERROR Fix failed
```