### PR TITLE
Fix how analyze prints when not attached to tty but input is redirected

### DIFF
--- a/scope/src/shared/capture.rs
+++ b/scope/src/shared/capture.rs
@@ -76,10 +76,16 @@ impl<R: io::AsyncRead + Unpin> StreamCapture<R> {
                     _ => info!("{}", line),
                 },
                 OutputDestination::StandardOut => {
-                    writeln!(self.writer.write().await, "{}", line).ok();
+                    writeln!(self.writer.write().await, "{}\r", line).ok();
                 }
                 OutputDestination::StandardOutWithPrefix(prefix) => {
-                    writeln!(self.writer.write().await, "{}:  {}", prefix.dimmed(), line).ok();
+                    writeln!(
+                        self.writer.write().await,
+                        "{}:  {}\r",
+                        prefix.dimmed(),
+                        line
+                    )
+                    .ok();
                 }
                 OutputDestination::Null => {}
             };


### PR DESCRIPTION
in this scenario, no carriage return was being printed, so the output from the command to be analyzed shifted right on each newline.

Fix it by adding a carriage return to force the cursor back to the left hand edge of the terminal.

Reproduction
---

Create this shell script in the `examples` directory

```sh
#! /bin/bash
# script and input redirect is used to force scope doctor to get input from the tty
script -q /dev/null bash -c 'scope doctor run --progress=plain' </dev/tty
```

And then analyze the output of the scope doctor command

```console
❯ cargo run --  analyze command --working-dir examples -- ./binsetup-test.sh
   Compiling dev-scope v2024.2.73 (/Users/chris.mcclellan/workspace/scope/scope)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.03s
     Running `target/debug/scope analyze command --working-dir examples -- ./binsetup-test.sh`
analyzing:   INFO Check was successful, group: "noop-1", name: "sleep 1"
                                                                        analyzing:   INFO Check was successful, group: "noop-1", name: "sleep 2"
                                                                                                                                                analyzing:   INFO Check was successful, group: "noop-2", name: "sleep 10"
                                      analyzing:   INFO Check was successful, group: "noop-2", name: "sleep 5"
                                                                                                              analyzing:   INFO Check was successful, group: "path-exists", name: "create path-exists file"
                        analyzing:   INFO Check was successful, group: "templated", name: "hushlogin"
                                                                                                     analyzing:  Summary: 4 groups succeeded
```

Solution
---

The `writeln!` macro does not write a carriage return
> On all platforms, the newline is the LINE FEED character (\n/U+000A) alone (no additional CARRIAGE RETURN (\r/U+000D).

https://doc.rust-lang.org/std/macro.writeln.html

Ensuring we explicitly write a carriage return fixes the output and has no effect in scenarios where we're not attached to a tty or are only attached to a tty.

```console
❯ cargo run --  analyze command --working-dir examples -- ./binsetup-test.sh
   Compiling dev-scope v2024.2.73 (/Users/chris.mcclellan/workspace/scope/scope)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2.67s
     Running `target/debug/scope analyze command --working-dir examples -- ./binsetup-test.sh`
analyzing:   INFO Check was successful, group: "noop-1", name: "sleep 1"
analyzing:   INFO Check was successful, group: "noop-1", name: "sleep 2"
analyzing:   INFO Check was successful, group: "noop-2", name: "sleep 10"
analyzing:   INFO Check was successful, group: "noop-2", name: "sleep 5"
analyzing:   INFO Check was successful, group: "path-exists", name: "create path-exists file"
analyzing:   INFO Check was successful, group: "templated", name: "hushlogin"
analyzing:  Summary: 4 groups succeeded
 INFO No known errors found
```