### PR TITLE
Add span w/return value for analyze_known_errors

### DIFF
--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -651,6 +651,7 @@ impl DefaultDoctorActionRun {
         })
     }
 
+    #[instrument(skip(self, fix_output), ret)]
     async fn analyze_known_errors(&self, fix_output: &[ActionTaskReport]) -> Result<AnalyzeStatus> {
         let lines = fix_output
             .iter()

--- a/scope/src/shared/analyze/status.rs
+++ b/scope/src/shared/analyze/status.rs
@@ -1,6 +1,6 @@
 use tracing::{error, info, warn};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub enum AnalyzeStatus {
     NoKnownErrorsFound,
     KnownErrorFoundNoFixFound,


### PR DESCRIPTION
Creates a new telemetry span for `analyze_known_errors` so we can track how often 
1. No known error was found 
1. An error was found, but it had no automated fix
1. A fix is found, but it failed
1. A fix is found and it succeeded
1. A fix was found, but the user denied it