### PR TITLE
Introduce DoctorCommand type

### DIFF
--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -522,7 +522,8 @@ impl DefaultDoctorActionRun {
 
         info!(
             "fix ran {} and exited {:?}",
-            command.text(), capture.exit_code
+            command.text(),
+            capture.exit_code
         );
 
         Ok(ActionTaskReport::from(&capture))
@@ -632,7 +633,8 @@ impl DefaultDoctorActionRun {
 
             info!(
                 "check ran command {} and result was {:?}",
-                command.text(), output.exit_code
+                command.text(),
+                output.exit_code
             );
 
             let command_result = match output.exit_code {
@@ -1148,9 +1150,7 @@ pub(crate) mod tests {
             .required(true)
             .check(
                 DoctorGroupActionCheckBuilder::default()
-                    .command(Some(DoctorCommands {
-                        commands: vec![DoctorCommand::from_str(check_command)],
-                    }))
+                    .command(Some(DoctorCommands::from(vec![check_command])))
                     .files(Some(DoctorGroupCachePath::from(("/foo", vec!["**/*"]))))
                     .build()
                     .unwrap(),
@@ -1208,9 +1208,7 @@ pub(crate) mod tests {
             .required(true)
             .check(
                 DoctorGroupActionCheckBuilder::default()
-                    .command(Some(DoctorCommands {
-                        commands: vec![DoctorCommand::from_str(check_command)],
-                    }))
+                    .command(Some(DoctorCommands::from(vec![check_command])))
                     .files(Some(DoctorGroupCachePath::from(("/foo", vec!["**/*"]))))
                     .build()
                     .unwrap(),
@@ -1439,14 +1437,14 @@ pub(crate) mod tests {
             );
 
             let (_highest_status_code, reports) = run
-                .run_commands(&DoctorCommands {
-                    commands: vec![DoctorCommand::try_new(
+                .run_commands(
+                    &DoctorCommands::from_commands(
                         Path::new("/some/dir"),
                         "/some/working/dir",
-                        "touch ~/.somefile",
+                        &vec!["touch ~/.somefile".to_string()],
                     )
-                    .unwrap()],
-                })
+                    .unwrap(),
+                )
                 .await
                 .unwrap();
             let report = reports[0].clone();

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -446,7 +446,7 @@ impl DefaultDoctorActionRun {
         let mut action_reports = Vec::new();
         let mut highest_exit_code = NO_COMMANDS_EXIT_CODE;
 
-        for command in &commands.commands {
+        for command in commands {
             let report = self.run_single_fix(command).await?;
             highest_exit_code = max(
                 highest_exit_code,
@@ -610,7 +610,7 @@ impl DefaultDoctorActionRun {
         let mut action_reports = Vec::new();
         let mut result: Option<CacheStatus> = None;
 
-        for command in &action_command.commands {
+        for command in action_command {
             let args = vec![command.text().to_string()];
             let path = format!(
                 "{}:{}",

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -504,7 +504,7 @@ impl DefaultDoctorActionRun {
         &self,
         command: &DoctorCommand,
     ) -> Result<ActionTaskReport, RuntimeError> {
-        let args = vec![command.text.to_string()];
+        let args = vec![command.text().to_string()];
         let capture = self
             .exec_runner
             .run_command(CaptureOpts {
@@ -522,7 +522,7 @@ impl DefaultDoctorActionRun {
 
         info!(
             "fix ran {} and exited {:?}",
-            command.text, capture.exit_code
+            command.text(), capture.exit_code
         );
 
         Ok(ActionTaskReport::from(&capture))
@@ -611,7 +611,7 @@ impl DefaultDoctorActionRun {
         let mut result: Option<CacheStatus> = None;
 
         for command in &action_command.commands {
-            let args = vec![command.text.to_string()];
+            let args = vec![command.text().to_string()];
             let path = format!(
                 "{}:{}",
                 self.model.metadata().containing_dir(),
@@ -632,7 +632,7 @@ impl DefaultDoctorActionRun {
 
             info!(
                 "check ran command {} and result was {:?}",
-                command.text, output.exit_code
+                command.text(), output.exit_code
             );
 
             let command_result = match output.exit_code {

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -1142,7 +1142,7 @@ pub(crate) mod tests {
             .check(
                 DoctorGroupActionCheckBuilder::default()
                     .command(Some(DoctorCommands {
-                        commands: vec![check_command.to_string()],
+                        commands: vec![DoctorCommand::from_str(check_command)],
                     }))
                     .files(Some(DoctorGroupCachePath::from(("/foo", vec!["**/*"]))))
                     .build()
@@ -1202,7 +1202,7 @@ pub(crate) mod tests {
             .check(
                 DoctorGroupActionCheckBuilder::default()
                     .command(Some(DoctorCommands {
-                        commands: vec![check_command.to_string()],
+                        commands: vec![DoctorCommand::from_str(check_command)],
                     }))
                     .files(Some(DoctorGroupCachePath::from(("/foo", vec!["**/*"]))))
                     .build()
@@ -1433,7 +1433,7 @@ pub(crate) mod tests {
 
             let (_highest_status_code, reports) = run
                 .run_commands(&DoctorCommands {
-                    commands: vec!["touch ~/.somefile".to_string()],
+                    commands: vec![DoctorCommand::from_str("touch ~/.somefile")],
                 })
                 .await
                 .unwrap();
@@ -1471,7 +1471,7 @@ pub(crate) mod tests {
             );
 
             let action_commands = DoctorCommandsBuilder::default()
-                .commands(vec!["test -f ~/.somefile".to_string()])
+                .commands(vec![DoctorCommand::from_str("test -f ~/.somefile")])
                 .build()
                 .unwrap();
 

--- a/scope/src/shared/analyze/mod.rs
+++ b/scope/src/shared/analyze/mod.rs
@@ -141,7 +141,7 @@ async fn run_fix(
     for cmd in &commands.commands {
         let capture_opts = CaptureOpts {
             working_dir,
-            args: &[cmd.text.to_string()],
+            args: &[cmd.text().to_string()],
             output_dest: OutputDestination::StandardOutWithPrefix("fixing".to_string()),
             path: exec_path,
             env_vars: generate_env_vars(),

--- a/scope/src/shared/analyze/mod.rs
+++ b/scope/src/shared/analyze/mod.rs
@@ -138,10 +138,10 @@ async fn run_fix(
     let commands = fix.command.as_ref().expect("Expected a command");
 
     let mut outputs = Vec::<OutputCapture>::new();
-    for cmd in commands.expand() {
+    for cmd in &commands.commands {
         let capture_opts = CaptureOpts {
             working_dir,
-            args: &[cmd],
+            args: &[cmd.text.to_string()],
             output_dest: OutputDestination::StandardOutWithPrefix("fixing".to_string()),
             path: exec_path,
             env_vars: generate_env_vars(),

--- a/scope/src/shared/analyze/mod.rs
+++ b/scope/src/shared/analyze/mod.rs
@@ -138,7 +138,7 @@ async fn run_fix(
     let commands = fix.command.as_ref().expect("Expected a command");
 
     let mut outputs = Vec::<OutputCapture>::new();
-    for cmd in &commands.commands {
+    for cmd in commands {
         let capture_opts = CaptureOpts {
             working_dir,
             args: &[cmd.text().to_string()],

--- a/scope/src/shared/models/internal/command.rs
+++ b/scope/src/shared/models/internal/command.rs
@@ -5,33 +5,36 @@ use std::path::Path;
 use super::{extract_command_path, substitute_templates};
 
 #[derive(Debug, PartialEq, Clone, Builder)]
-#[builder(setter(into))]
-pub struct DoctorCommands {
-    pub commands: Vec<String>,
+pub struct DoctorCommand {
+    text: String,
 }
 
-impl DoctorCommands {
-    pub fn from_commands(
-        containing_dir: &Path,
-        working_dir: &str,
-        commands: &Vec<String>,
-    ) -> Result<DoctorCommands> {
-        let mut templated_commands = Vec::new();
-        for command in commands {
-            templated_commands.push(substitute_templates(working_dir, command)?);
+impl DoctorCommand {
+    pub fn try_new(containing_dir: &Path, working_dir: &str, command: &str) -> Result<Self> {
+        let rendered_cmd = substitute_templates(working_dir, command)?;
+        let qualified_cmd = extract_command_path(containing_dir, &rendered_cmd);
+        Ok(DoctorCommand::from_str(&qualified_cmd))
+    }
+
+    /// Performs no template rendering, path qualification, or shell expansion.
+    /// This is useful for when you want to use a command as-is, without any modifications
+    ///
+    // We don't want to implement FromStr for DoctorCommand because we're not parsing a string into an instance.
+    // Calling this with cmd.parse() doesn't make sense here.
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(cmd: &str) -> Self {
+        DoctorCommand {
+            text: cmd.to_string(),
         }
-        Ok(DoctorCommands::from((containing_dir, templated_commands)))
     }
 
-    /// Performs shell expansion
-    pub fn expand(&self) -> Vec<String> {
-        self.commands
-            .iter()
-            .map(|cmd| Self::expand_command(cmd))
-            .collect()
-    }
-
+    //TODO: I would prefer this to happen in the constructor
     /// splits a commands and performs shell expansion its parts
+    pub fn expand(&self) -> String {
+        Self::expand_command(&self.text)
+    }
+
+    // keeping this to make it easier to do in a constructor later
     fn expand_command(command: &str) -> String {
         command
             .split(' ')
@@ -42,20 +45,29 @@ impl DoctorCommands {
     }
 }
 
-impl<T> From<(&Path, Vec<T>)> for DoctorCommands
-where
-    String: for<'a> From<&'a T>,
-{
-    fn from((base_path, command_strings): (&Path, Vec<T>)) -> Self {
-        let commands = command_strings
-            .iter()
-            .map(|s| {
-                let exec: String = s.into();
-                extract_command_path(base_path, &exec)
-            })
-            .collect();
+#[derive(Debug, PartialEq, Clone, Builder)]
+#[builder(setter(into))]
+pub struct DoctorCommands {
+    pub commands: Vec<DoctorCommand>,
+}
 
-        DoctorCommands { commands }
+impl DoctorCommands {
+    pub fn from_commands(
+        containing_dir: &Path,
+        working_dir: &str,
+        // commands: &Vec<String>,
+        commands: &[String],
+    ) -> Result<DoctorCommands> {
+        commands
+            .iter()
+            .map(|command| DoctorCommand::try_new(containing_dir, working_dir, command))
+            .collect::<Result<Vec<_>>>()
+            .map(|commands| DoctorCommands { commands })
+    }
+
+    /// Performs shell expansion
+    pub fn expand(&self) -> Vec<String> {
+        self.commands.iter().map(|cmd| cmd.expand()).collect()
     }
 }
 
@@ -64,7 +76,10 @@ impl From<Vec<&str>> for DoctorCommands {
     /// This is only used by some tests and should NOT be used in production code
     /// because it does not properly pre-pend the command with a base path.
     fn from(value: Vec<&str>) -> Self {
-        let commands = value.iter().map(|x| x.to_string()).collect();
+        let commands = value
+            .iter()
+            .map(|cmd| DoctorCommand::from_str(cmd))
+            .collect();
         Self { commands }
     }
 }
@@ -81,26 +96,9 @@ mod tests {
 
         assert_eq!(
             DoctorCommands {
-                commands: vec![input[0].to_string(), input[1].to_string(),]
-            },
-            actual
-        )
-    }
-
-    #[test]
-    fn from_path_and_vec_string() {
-        let base_path = Path::new("/foo/bar");
-        let input = vec!["echo 'foo'", "baz/qux", "./qux"];
-
-        let actual =
-            DoctorCommands::from((base_path, input.iter().map(|cmd| cmd.to_string()).collect()));
-
-        assert_eq!(
-            DoctorCommands {
                 commands: vec![
-                    "echo 'foo'".to_string(),
-                    "baz/qux".to_string(),
-                    "/foo/bar/qux".to_string(),
+                    DoctorCommand::from_str(input[0]),
+                    DoctorCommand::from_str(input[1]),
                 ]
             },
             actual
@@ -108,7 +106,34 @@ mod tests {
     }
 
     #[test]
-    fn from_commands_succeeds() {
+    fn from_commands_inserts_execution_path() {
+        let base_path = Path::new("/foo/bar");
+        let input = vec!["echo 'foo'", "baz/qux", "./qux"];
+
+        let actual = DoctorCommands::from_commands(
+            base_path,
+            "/some/working_dir",
+            &input
+                .iter()
+                .map(|cmd| cmd.to_string())
+                .collect::<Vec<String>>(),
+        )
+        .expect("Expected Ok");
+
+        assert_eq!(
+            DoctorCommands {
+                commands: vec![
+                    DoctorCommand::from_str("echo 'foo'"),
+                    DoctorCommand::from_str("baz/qux"),
+                    DoctorCommand::from_str("/foo/bar/qux"),
+                ]
+            },
+            actual
+        )
+    }
+
+    #[test]
+    fn from_commands_inserts_working_dir() {
         let containing_dir = Path::new("/foo/bar");
         let working_dir = "/some/working_dir";
         let commands = vec!["{{ working_dir }}/foo.sh", "./bar.sh"]
@@ -119,12 +144,12 @@ mod tests {
         let actual = DoctorCommands::from_commands(containing_dir, working_dir, &commands)
             .expect("Expected Ok");
 
-        let templated_commands = commands
-            .iter()
-            .map(|cmd| substitute_templates(&working_dir, &cmd).unwrap())
-            .collect::<Vec<String>>();
-
-        let expected = DoctorCommands::from((containing_dir, templated_commands));
+        let expected = DoctorCommands {
+            commands: vec![
+                DoctorCommand::from_str("/some/working_dir/foo.sh"),
+                DoctorCommand::from_str("/foo/bar/bar.sh"),
+            ],
+        };
 
         assert_eq!(expected, actual)
     }

--- a/scope/src/shared/models/internal/command.rs
+++ b/scope/src/shared/models/internal/command.rs
@@ -153,4 +153,177 @@ mod tests {
 
         assert_eq!(expected, actual)
     }
+
+    mod try_new_tests {
+        use super::*;
+
+        #[test]
+        fn try_new_with_simple_command() {
+            let containing_dir = Path::new("/foo/bar");
+            let working_dir = "/some/working_dir";
+            let command = "echo hello";
+
+            let actual = DoctorCommand::try_new(containing_dir, working_dir, command)
+                .expect("Expected Ok");
+
+            let expected = DoctorCommand::from_str("echo hello");
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn try_new_with_working_dir_template() {
+            let containing_dir = Path::new("/foo/bar");
+            let working_dir = "/some/working_dir";
+            let command = "{{ working_dir }}/script.sh";
+
+            let actual = DoctorCommand::try_new(containing_dir, working_dir, command)
+                .expect("Expected Ok");
+
+            let expected = DoctorCommand::from_str("/some/working_dir/script.sh");
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn try_new_with_relative_path() {
+            let containing_dir = Path::new("/foo/bar");
+            let working_dir = "/some/working_dir";
+            let command = "./script.sh";
+
+            let actual = DoctorCommand::try_new(containing_dir, working_dir, command)
+                .expect("Expected Ok");
+
+            let expected = DoctorCommand::from_str("/foo/bar/script.sh");
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn try_new_with_relative_path_and_args() {
+            let containing_dir = Path::new("/foo/bar");
+            let working_dir = "/some/working_dir";
+            let command = "./script.sh --verbose";
+
+            let actual = DoctorCommand::try_new(containing_dir, working_dir, command)
+                .expect("Expected Ok");
+
+            let expected = DoctorCommand::from_str("/foo/bar/script.sh --verbose");
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn try_new_with_template_and_relative_path() {
+            let containing_dir = Path::new("/project/root");
+            let working_dir = "/build/dir";
+            let command = "{{ working_dir }}/check.sh && ./validate.sh";
+
+            let actual = DoctorCommand::try_new(containing_dir, working_dir, command)
+                .expect("Expected Ok");
+
+            // extract_command_path only processes the first command/token, 
+            // not all relative paths in the entire command string
+            // This is likely a BUG in the extract_command_path() implementation
+            let expected = DoctorCommand::from_str("/build/dir/check.sh && ./validate.sh");
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn try_new_with_absolute_path() {
+            let containing_dir = Path::new("/foo/bar");
+            let working_dir = "/some/working_dir";
+            let command = "/usr/bin/env python3 test.py";
+
+            let actual = DoctorCommand::try_new(containing_dir, working_dir, command)
+                .expect("Expected Ok");
+
+            let expected = DoctorCommand::from_str("/usr/bin/env python3 test.py");
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn try_new_with_unknown_template() {
+            let containing_dir = Path::new("/foo/bar");
+            let working_dir = "/some/working_dir";
+            let command = "{{ unknown_template }}/script.sh";
+
+            let actual = DoctorCommand::try_new(containing_dir, working_dir, command)
+                .expect("Expected Ok");
+
+            // Unknown templates are erased (current behavior)
+            // I can argue that this should error instead, but for now we document its behavior
+            let expected = DoctorCommand::from_str("/script.sh");
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn try_new_with_nested_relative_path() {
+            let containing_dir = Path::new("/project/root");
+            let working_dir = "/build/dir";
+            let command = "./scripts/build.sh";
+
+            let actual = DoctorCommand::try_new(containing_dir, working_dir, command)
+                .expect("Expected Ok");
+
+            let expected = DoctorCommand::from_str("/project/root/scripts/build.sh");
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn try_new_with_empty_command() {
+            let containing_dir = Path::new("/foo/bar");
+            let working_dir = "/some/working_dir";
+            let command = "";
+
+            let actual = DoctorCommand::try_new(containing_dir, working_dir, command)
+                .expect("Expected Ok");
+
+            // Empty string split produces a single empty string, not an empty iterator
+            // This case should probably return an error instead of an empty command
+            // but for now we document its behavior
+            let expected = DoctorCommand::from_str("");
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn try_new_with_complex_command() {
+            let containing_dir = Path::new("/project");
+            let working_dir = "/work";
+            let command = "cd {{ working_dir }} && ./build.sh && echo 'done'";
+
+            let actual = DoctorCommand::try_new(containing_dir, working_dir, command)
+                .expect("Expected Ok");
+
+            // extract_command_path only processes the first command/token,
+            // not all relative paths in the entire command string
+            // This is likely a BUG in the extract_command_path() implementation
+            let expected = DoctorCommand::from_str("cd /work && ./build.sh && echo 'done'");
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn try_new_with_multiple_templates() {
+            let containing_dir = Path::new("/project");
+            let working_dir = "/build";
+            let command = "{{ working_dir }}/setup.sh && {{ working_dir }}/build.sh";
+
+            let actual = DoctorCommand::try_new(containing_dir, working_dir, command)
+                .expect("Expected Ok");
+
+            // Multiple templates should all be substituted
+            let expected = DoctorCommand::from_str("/build/setup.sh && /build/build.sh");
+            assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn try_new_with_whitespace_only_command() {
+            let containing_dir = Path::new("/foo/bar");
+            let working_dir = "/some/working_dir";
+            let command = "   ";
+
+            let actual = DoctorCommand::try_new(containing_dir, working_dir, command)
+                .expect("Expected Ok");
+
+            // Whitespace should be preserved
+            let expected = DoctorCommand::from_str("   ");
+            assert_eq!(expected, actual);
+        }
+    }
 }

--- a/scope/src/shared/models/internal/command.rs
+++ b/scope/src/shared/models/internal/command.rs
@@ -64,6 +64,20 @@ impl DoctorCommands {
             .collect::<Result<Vec<_>>>()
             .map(|commands| DoctorCommands { commands })
     }
+
+    /// Returns an iterator over the commands
+    pub fn iter(&self) -> std::slice::Iter<'_, DoctorCommand> {
+        self.commands.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a DoctorCommands {
+    type Item = &'a DoctorCommand;
+    type IntoIter = std::slice::Iter<'a, DoctorCommand>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
 }
 
 #[cfg(test)]
@@ -352,6 +366,65 @@ mod tests {
                 home_dir, home_dir
             ));
             assert_eq!(expected, actual);
+        }
+    }
+
+    mod iterator_tests {
+        use super::*;
+
+        #[test]
+        fn iter_returns_command_references() {
+            let commands = DoctorCommands::from(vec!["echo hello", "ls -la", "pwd"]);
+
+            let command_refs: Vec<&DoctorCommand> = commands.iter().collect();
+
+            assert_eq!(command_refs.len(), 3);
+            assert_eq!(command_refs[0].text(), "echo hello");
+            assert_eq!(command_refs[1].text(), "ls -la");
+            assert_eq!(command_refs[2].text(), "pwd");
+        }
+
+        #[test]
+        fn into_iter_returns_command_references() {
+            let commands = DoctorCommands::from(vec!["echo hello", "ls -la", "pwd"]);
+
+            let command_refs: Vec<&DoctorCommand> = (&commands).into_iter().collect();
+
+            assert_eq!(command_refs.len(), 3);
+            assert_eq!(command_refs[0].text(), "echo hello");
+            assert_eq!(command_refs[1].text(), "ls -la");
+            assert_eq!(command_refs[2].text(), "pwd");
+        }
+
+        #[test]
+        fn iter_works_with_for_loop() {
+            let commands = DoctorCommands::from(vec!["echo hello", "ls -la", "pwd"]);
+            let mut collected = Vec::new();
+
+            for command in &commands {
+                collected.push(command.text());
+            }
+
+            assert_eq!(collected, vec!["echo hello", "ls -la", "pwd"]);
+        }
+
+        #[test]
+        fn iter_works_with_empty_commands() {
+            let commands = DoctorCommands::from(vec![]);
+
+            let command_refs: Vec<&DoctorCommand> = commands.iter().collect();
+
+            assert_eq!(command_refs.len(), 0);
+        }
+
+        #[test]
+        fn iter_works_with_single_command() {
+            let commands = DoctorCommands::from(vec!["single command"]);
+
+            let command_refs: Vec<&DoctorCommand> = commands.iter().collect();
+
+            assert_eq!(command_refs.len(), 1);
+            assert_eq!(command_refs[0].text(), "single command");
         }
     }
 }

--- a/scope/src/shared/models/internal/command.rs
+++ b/scope/src/shared/models/internal/command.rs
@@ -6,7 +6,7 @@ use super::{extract_command_path, substitute_templates};
 
 #[derive(Debug, PartialEq, Clone, Builder)]
 pub struct DoctorCommand {
-    pub text: String,
+    text: String,
 }
 
 impl DoctorCommand {
@@ -27,6 +27,11 @@ impl DoctorCommand {
         DoctorCommand {
             text: cmd.to_string(),
         }
+    }
+
+    /// Returns the command text
+    pub fn text(&self) -> &str {
+        &self.text
     }
 
     // keeping this to make it easier to do in a constructor later

--- a/scope/src/shared/models/internal/command.rs
+++ b/scope/src/shared/models/internal/command.rs
@@ -48,14 +48,13 @@ impl DoctorCommand {
 #[derive(Debug, PartialEq, Clone, Builder)]
 #[builder(setter(into))]
 pub struct DoctorCommands {
-    pub commands: Vec<DoctorCommand>,
+    commands: Vec<DoctorCommand>,
 }
 
 impl DoctorCommands {
     pub fn from_commands(
         containing_dir: &Path,
         working_dir: &str,
-        // commands: &Vec<String>,
         commands: &[String],
     ) -> Result<DoctorCommands> {
         commands
@@ -103,15 +102,8 @@ mod tests {
 
         let actual = DoctorCommands::from(input.clone());
 
-        assert_eq!(
-            DoctorCommands {
-                commands: vec![
-                    DoctorCommand::from_str(input[0]),
-                    DoctorCommand::from_str(input[1]),
-                ]
-            },
-            actual
-        )
+        let expected = DoctorCommands::from(vec!["echo 'foo'", "false"]);
+        assert_eq!(expected, actual)
     }
 
     #[test]
@@ -129,16 +121,8 @@ mod tests {
         )
         .expect("Expected Ok");
 
-        assert_eq!(
-            DoctorCommands {
-                commands: vec![
-                    DoctorCommand::from_str("echo 'foo'"),
-                    DoctorCommand::from_str("baz/qux"),
-                    DoctorCommand::from_str("/foo/bar/qux"),
-                ]
-            },
-            actual
-        )
+        let expected = DoctorCommands::from(vec!["echo 'foo'", "baz/qux", "/foo/bar/qux"]);
+        assert_eq!(expected, actual)
     }
 
     #[test]
@@ -153,12 +137,7 @@ mod tests {
         let actual = DoctorCommands::from_commands(containing_dir, working_dir, &commands)
             .expect("Expected Ok");
 
-        let expected = DoctorCommands {
-            commands: vec![
-                DoctorCommand::from_str("/some/working_dir/foo.sh"),
-                DoctorCommand::from_str("/foo/bar/bar.sh"),
-            ],
-        };
+        let expected = DoctorCommands::from(vec!["/some/working_dir/foo.sh", "/foo/bar/bar.sh"]);
 
         assert_eq!(expected, actual)
     }


### PR DESCRIPTION
Better encapsulation and typing.

Previously, we were just passing raw strings around.
This type helps us ensure that we're getting commands where we expect commands
and that they have been properly initialized by rendering templates, replacing `./` with the working directory, and expanding `~` to the home directory everywhere.

Also implements an iterator for `DoctorCommands` to make that type easier to work with, as well as making its `command` field private.

This all adds up to better ensure that commands users give us are pre-processed correctly before executing them.