### PR TITLE
Cache at action level instead of group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,6 +674,7 @@ dependencies = [
  "shellexpand",
  "strip-ansi-escapes",
  "strum",
+ "tempfile",
  "thiserror",
  "time",
  "tokio",

--- a/scope/Cargo.toml
+++ b/scope/Cargo.toml
@@ -87,6 +87,7 @@ assert_cmd = "2.0.16"
 assert_fs = "1.1.2"
 escargot = "0.5.12"
 predicates = "3.1.2"
+tempfile = "3.0"
 
 [build-dependencies]
 vergen = { version = "8.3", features = ["build", "git", "git2"] }

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -763,7 +763,7 @@ impl GlobWalker for DefaultGlobWalker {
 
             for path in files {
                 let file_result = file_cache
-                    .check_file(cache_name.to_string(), action_name.to_string(), &path)
+                    .check_file(cache_name, action_name, &path)
                     .await?;
                 debug!(target: "user", "CacheStatus for file {}: {:?}", path.display(), file_result);
                 let check_result = file_result == FileCacheStatus::FileMatches;
@@ -788,7 +788,7 @@ impl GlobWalker for DefaultGlobWalker {
             let glob_path = make_absolute(base_dir, glob_str);
             for path in self.file_system.find_files(&glob_path)? {
                 file_cache
-                    .update_cache_entry(cache_name.to_string(), action_name.to_string(), &path)
+                    .update_cache_entry(cache_name, action_name, &path)
                     .await?;
             }
         }

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -268,6 +268,7 @@ impl DefaultDoctorActionRun {
                     &cache_path.base_path,
                     &cache_path.paths,
                     &self.model.metadata.name(),
+                    &self.action.name,
                     self.file_cache.clone(),
                 )
                 .await;
@@ -592,6 +593,7 @@ impl DefaultDoctorActionRun {
                 &paths.base_path,
                 &paths.paths,
                 &self.model.metadata.name(),
+                &self.action.name,
                 self.file_cache.clone(),
             )
             .await?;
@@ -682,6 +684,7 @@ pub trait GlobWalker: Send + Sync {
         base_dir: &Path,
         paths: &[String],
         cache_name: &str,
+        action_name: &str,
         file_cache: Arc<dyn FileCache>,
     ) -> Result<bool, RuntimeError>;
 
@@ -690,6 +693,7 @@ pub trait GlobWalker: Send + Sync {
         base_dir: &Path,
         paths: &[String],
         cache_name: &str,
+        action_name: &str,
         file_cache: Arc<dyn FileCache>,
     ) -> Result<(), RuntimeError>;
 }
@@ -746,6 +750,7 @@ impl GlobWalker for DefaultGlobWalker {
         base_dir: &Path,
         paths: &[String],
         cache_name: &str,
+        action_name: &str,
         file_cache: Arc<dyn FileCache>,
     ) -> Result<bool, RuntimeError> {
         for glob_str in paths {
@@ -757,7 +762,9 @@ impl GlobWalker for DefaultGlobWalker {
             }
 
             for path in files {
-                let file_result = file_cache.check_file(cache_name.to_string(), &path).await?;
+                let file_result = file_cache
+                    .check_file(cache_name.to_string(), action_name.to_string(), &path)
+                    .await?;
                 debug!(target: "user", "CacheStatus for file {}: {:?}", path.display(), file_result);
                 let check_result = file_result == FileCacheStatus::FileMatches;
                 if !check_result {
@@ -774,13 +781,14 @@ impl GlobWalker for DefaultGlobWalker {
         base_dir: &Path,
         paths: &[String],
         cache_name: &str,
+        action_name: &str,
         file_cache: Arc<dyn FileCache>,
     ) -> Result<(), RuntimeError> {
         for glob_str in paths {
             let glob_path = make_absolute(base_dir, glob_str);
             for path in self.file_system.find_files(&glob_path)? {
                 file_cache
-                    .update_cache_entry(cache_name.to_string(), &path)
+                    .update_cache_entry(cache_name.to_string(), action_name.to_string(), &path)
                     .await?;
             }
         }
@@ -1068,11 +1076,11 @@ pub(crate) mod tests {
         glob_walker
             .expect_have_globs_changed()
             .times(1)
-            .returning(|_, _, _, _| Ok(false));
+            .returning(|_, _, _, _, _| Ok(false));
         glob_walker
             .expect_update_cache()
             .times(1)
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _, _, _, _| Ok(()));
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
@@ -1098,11 +1106,11 @@ pub(crate) mod tests {
         glob_walker
             .expect_have_globs_changed()
             .times(1)
-            .returning(|_, _, _, _| Ok(false));
+            .returning(|_, _, _, _, _| Ok(false));
         glob_walker
             .expect_update_cache()
             .times(1)
-            .returning(|_, _, _, _| Err(RuntimeError::AnyError(anyhow!("bogus error"))));
+            .returning(|_, _, _, _, _| Err(RuntimeError::AnyError(anyhow!("bogus error"))));
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
 
@@ -1128,7 +1136,7 @@ pub(crate) mod tests {
         glob_walker
             .expect_have_globs_changed()
             .times(1)
-            .returning(|_, _, _, _| Ok(false));
+            .returning(|_, _, _, _, _| Ok(false));
         glob_walker.expect_update_cache().never();
 
         let run = setup_test(vec![action], exec_runner, glob_walker);
@@ -1170,11 +1178,11 @@ pub(crate) mod tests {
         glob_walker
             .expect_have_globs_changed()
             .times(1)
-            .returning(|_, _, _, _| Ok(true));
+            .returning(|_, _, _, _, _| Ok(true));
         glob_walker
             .expect_update_cache()
             .once()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _, _, _, _| Ok(()));
 
         exec_runner
             .expect_run_command()
@@ -1228,11 +1236,11 @@ pub(crate) mod tests {
         glob_walker
             .expect_have_globs_changed()
             .times(1)
-            .returning(|_, _, _, _| Ok(false));
+            .returning(|_, _, _, _, _| Ok(false));
         glob_walker
             .expect_update_cache()
             .once()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _, _, _, _| Ok(()));
 
         exec_runner
             .expect_run_command()
@@ -1267,9 +1275,10 @@ pub(crate) mod tests {
             .once()
             .with(
                 predicate::eq("file_cache".to_string()),
+                predicate::eq("action_name".to_string()),
                 predicate::eq(Path::new("/foo/bar")),
             )
-            .returning(|_, _| Ok(()));
+            .returning(|_, _, _| Ok(()));
 
         file_system
             .expect_find_files()
@@ -1286,6 +1295,7 @@ pub(crate) mod tests {
                 Path::new("/foo/root"),
                 &["*.txt".to_string()],
                 "file_cache",
+                "action_name",
                 Arc::new(file_cache),
             )
             .await;
@@ -1302,9 +1312,10 @@ pub(crate) mod tests {
             .once()
             .with(
                 predicate::eq("file_cache".to_string()),
+                predicate::eq("action_name".to_string()),
                 predicate::eq(Path::new("/foo/bar")),
             )
-            .returning(|_, _| Ok(()));
+            .returning(|_, _, _| Ok(()));
 
         file_system
             .expect_find_files()
@@ -1321,6 +1332,7 @@ pub(crate) mod tests {
                 Path::new("/foo/root"),
                 &["/a/abs/path/*.txt".to_string()],
                 "file_cache",
+                "action_name",
                 Arc::new(file_cache),
             )
             .await;
@@ -1340,9 +1352,10 @@ pub(crate) mod tests {
             .once()
             .with(
                 predicate::eq("group_name".to_string()),
+                predicate::eq("action_name".to_string()),
                 predicate::eq(resolved_path.clone()),
             )
-            .returning(|_, _| Ok(()));
+            .returning(|_, _, _| Ok(()));
 
         file_system
             .expect_find_files()
@@ -1367,6 +1380,7 @@ pub(crate) mod tests {
                 Path::new("/foo/root"),
                 &["~/path/*.txt".to_string()],
                 "group_name",
+                "action_name",
                 Arc::new(file_cache),
             )
             .await;
@@ -1385,9 +1399,10 @@ pub(crate) mod tests {
             .once()
             .with(
                 predicate::eq("group_name".to_string()),
+                predicate::eq("action_name".to_string()),
                 predicate::eq(Path::new("/foo/path/foo.txt")),
             )
-            .returning(|_, _| Ok(()));
+            .returning(|_, _, _| Ok(()));
 
         file_system
             .expect_find_files()
@@ -1407,6 +1422,7 @@ pub(crate) mod tests {
                 Path::new("/foo/root"),
                 &["../path/*.txt".to_string()],
                 "group_name",
+                "action_name",
                 Arc::new(file_cache),
             )
             .await;

--- a/scope/src/doctor/file_cache.rs
+++ b/scope/src/doctor/file_cache.rs
@@ -46,6 +46,8 @@ impl FileCache for NoOpCache {
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 struct FileCacheData {
+    // group-name: { action-name: { file-path: checksum } }
+    // checksums: BTreeMap<String, BTreeMap<String, BTreeMap<String, String>>>,
     #[serde(default)]
     checksums: BTreeMap<String, BTreeMap<String, String>>,
 }
@@ -156,4 +158,565 @@ async fn make_checksum(path: &Path) -> Result<String> {
     }
 
     Ok(sha256::try_async_digest(path).await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::{tempdir, TempDir};
+
+    /// Helper function to create a temporary directory and file for testing
+    fn setup_temp_cache() -> (TempDir, PathBuf) {
+        let temp_dir = tempdir().unwrap();
+        let cache_path = temp_dir.path().join("test_cache.json");
+        (temp_dir, cache_path)
+    }
+
+    /// Helper function to create a test file with content
+    fn create_test_file(temp_dir: &TempDir, name: &str, content: &str) -> PathBuf {
+        let file_path = temp_dir.path().join(name);
+        fs::write(&file_path, content).unwrap();
+        file_path
+    }
+
+    mod file_based_cache {
+        use super::*;
+
+        #[tokio::test]
+        async fn test_new_cache_with_nonexistent_file() {
+            let (_temp_dir, cache_path) = setup_temp_cache();
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+
+            assert_eq!(cache.path, cache_path.display().to_string());
+
+            // Should return FileChanged for any file since cache is empty
+            let status = cache
+                .check_file("test-group".to_string(), &cache_path)
+                .await
+                .unwrap();
+            assert_eq!(status, FileCacheStatus::FileChanged);
+        }
+
+        #[tokio::test]
+        async fn test_new_cache_with_valid_existing_file() {
+            let (_temp_dir, cache_path) = setup_temp_cache();
+
+            // Create a valid cache file
+            let cache_data = r#"{"checksums":{"test-group":{"/test/file":"abcd1234"}}}"#;
+            fs::write(&cache_path, cache_data).unwrap();
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+            assert_eq!(cache.path, cache_path.display().to_string());
+        }
+
+        #[tokio::test]
+        async fn test_new_cache_with_invalid_json() {
+            let (_temp_dir, cache_path) = setup_temp_cache();
+
+            // Create an invalid JSON file
+            fs::write(&cache_path, "invalid json").unwrap();
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+
+            // Should still create cache but with empty data
+            let status = cache
+                .check_file("test-group".to_string(), &cache_path)
+                .await
+                .unwrap();
+            assert_eq!(status, FileCacheStatus::FileChanged);
+        }
+
+        #[tokio::test]
+        async fn test_check_file_not_in_cache() {
+            let (temp_dir, cache_path) = setup_temp_cache();
+            let test_file = create_test_file(&temp_dir, "test.txt", "content");
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+
+            let status = cache
+                .check_file("test-group".to_string(), &test_file)
+                .await
+                .unwrap();
+            assert_eq!(status, FileCacheStatus::FileChanged);
+        }
+
+        #[tokio::test]
+        async fn test_check_file_matches_cache() {
+            let (temp_dir, cache_path) = setup_temp_cache();
+            let test_file = create_test_file(&temp_dir, "test.txt", "content");
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+
+            // First update the cache
+            cache
+                .update_cache_entry("test-group".to_string(), &test_file)
+                .await
+                .unwrap();
+
+            // Then check - should match
+            let status = cache
+                .check_file("test-group".to_string(), &test_file)
+                .await
+                .unwrap();
+            assert_eq!(status, FileCacheStatus::FileMatches);
+        }
+
+        #[tokio::test]
+        async fn test_check_file_changed_content() {
+            let (temp_dir, cache_path) = setup_temp_cache();
+            let test_file = create_test_file(&temp_dir, "test.txt", "original content");
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+
+            // Update cache with original content
+            cache
+                .update_cache_entry("test-group".to_string(), &test_file)
+                .await
+                .unwrap();
+
+            // Modify the file
+            fs::write(&test_file, "modified content").unwrap();
+
+            // Should detect change
+            let status = cache
+                .check_file("test-group".to_string(), &test_file)
+                .await
+                .unwrap();
+            assert_eq!(status, FileCacheStatus::FileChanged);
+        }
+
+        #[tokio::test]
+        async fn test_check_nonexistent_file() {
+            let (_temp_dir, cache_path) = setup_temp_cache();
+            let nonexistent_file = PathBuf::from("/nonexistent/file.txt");
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+
+            let status = cache
+                .check_file("test-group".to_string(), &nonexistent_file)
+                .await
+                .unwrap();
+            assert_eq!(status, FileCacheStatus::FileChanged);
+        }
+
+        #[tokio::test]
+        async fn test_check_directory() {
+            let (temp_dir, cache_path) = setup_temp_cache();
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+
+            let status = cache
+                .check_file("test-group".to_string(), temp_dir.path())
+                .await
+                .unwrap();
+            assert_eq!(status, FileCacheStatus::FileChanged);
+        }
+
+        #[tokio::test]
+        async fn test_update_cache_entry() {
+            let (temp_dir, cache_path) = setup_temp_cache();
+            let test_file = create_test_file(&temp_dir, "test.txt", "content");
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+
+            // Update cache entry
+            cache
+                .update_cache_entry("test-group".to_string(), &test_file)
+                .await
+                .unwrap();
+
+            // Verify it was added
+            let status = cache
+                .check_file("test-group".to_string(), &test_file)
+                .await
+                .unwrap();
+            assert_eq!(status, FileCacheStatus::FileMatches);
+        }
+
+        #[tokio::test]
+        async fn test_update_cache_entry_nonexistent_file() {
+            let (_temp_dir, cache_path) = setup_temp_cache();
+            let nonexistent_file = PathBuf::from("/nonexistent/file.txt");
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+
+            // Should not panic or error
+            cache
+                .update_cache_entry("test-group".to_string(), &nonexistent_file)
+                .await
+                .unwrap();
+
+            // Check should return FileMatches since the file consistently doesn't exist
+            let status = cache
+                .check_file("test-group".to_string(), &nonexistent_file)
+                .await
+                .unwrap();
+            assert_eq!(status, FileCacheStatus::FileMatches);
+        }
+
+        #[tokio::test]
+        async fn test_multiple_groups_cache_separately() {
+            let (temp_dir, cache_path) = setup_temp_cache();
+            let test_file1 = create_test_file(&temp_dir, "test1.txt", "content1");
+            let test_file2 = create_test_file(&temp_dir, "test2.txt", "content2");
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+
+            // Update different groups
+            cache
+                .update_cache_entry("group1".to_string(), &test_file1)
+                .await
+                .unwrap();
+            cache
+                .update_cache_entry("group2".to_string(), &test_file2)
+                .await
+                .unwrap();
+
+            // Both should match their respective groups
+            let status1 = cache
+                .check_file("group1".to_string(), &test_file1)
+                .await
+                .unwrap();
+            let status2 = cache
+                .check_file("group2".to_string(), &test_file2)
+                .await
+                .unwrap();
+
+            assert_eq!(status1, FileCacheStatus::FileMatches);
+            assert_eq!(status2, FileCacheStatus::FileMatches);
+        }
+
+        #[tokio::test]
+        async fn test_cross_group_checks_fail() {
+            let (temp_dir, cache_path) = setup_temp_cache();
+            let test_file1 = create_test_file(&temp_dir, "test1.txt", "content1");
+            let test_file2 = create_test_file(&temp_dir, "test2.txt", "content2");
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+
+            // Update different groups
+            cache
+                .update_cache_entry("group1".to_string(), &test_file1)
+                .await
+                .unwrap();
+            cache
+                .update_cache_entry("group2".to_string(), &test_file2)
+                .await
+                .unwrap();
+
+            // Cross-group checks should fail
+            let status_cross = cache
+                .check_file("group1".to_string(), &test_file2)
+                .await
+                .unwrap();
+            assert_eq!(status_cross, FileCacheStatus::FileChanged);
+        }
+
+        #[tokio::test]
+        async fn test_same_file_different_groups() {
+            let (temp_dir, cache_path) = setup_temp_cache();
+            let test_file = create_test_file(&temp_dir, "test.txt", "content");
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+
+            // Update same file in different groups
+            cache
+                .update_cache_entry("group1".to_string(), &test_file)
+                .await
+                .unwrap();
+            cache
+                .update_cache_entry("group2".to_string(), &test_file)
+                .await
+                .unwrap();
+
+            // Both groups should match
+            let status1 = cache
+                .check_file("group1".to_string(), &test_file)
+                .await
+                .unwrap();
+            let status2 = cache
+                .check_file("group2".to_string(), &test_file)
+                .await
+                .unwrap();
+
+            assert_eq!(status1, FileCacheStatus::FileMatches);
+            assert_eq!(status2, FileCacheStatus::FileMatches);
+        }
+
+        #[tokio::test]
+        async fn test_persist_creates_cache_file() {
+            let (temp_dir, cache_path) = setup_temp_cache();
+            let test_file = create_test_file(&temp_dir, "test.txt", "content");
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+            cache
+                .update_cache_entry("test-group".to_string(), &test_file)
+                .await
+                .unwrap();
+
+            cache.persist().await.unwrap();
+
+            assert!(cache_path.exists());
+        }
+
+        #[tokio::test]
+        async fn test_persist_creates_valid_json() {
+            let (temp_dir, cache_path) = setup_temp_cache();
+            let test_file = create_test_file(&temp_dir, "test.txt", "content");
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+            cache
+                .update_cache_entry("test-group".to_string(), &test_file)
+                .await
+                .unwrap();
+
+            cache.persist().await.unwrap();
+
+            let content = fs::read_to_string(&cache_path).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+
+            assert!(parsed["checksums"].is_object());
+            assert!(parsed["checksums"]["test-group"].is_object());
+        }
+
+        #[tokio::test]
+        async fn test_persist_creates_parent_directory() {
+            let temp_dir = tempdir().unwrap();
+            let nested_path = temp_dir
+                .path()
+                .join("nested")
+                .join("dir")
+                .join("cache.json");
+
+            let cache = FileBasedCache::new(&nested_path).unwrap();
+            let test_file = create_test_file(&temp_dir, "test.txt", "content");
+            cache
+                .update_cache_entry("test-group".to_string(), &test_file)
+                .await
+                .unwrap();
+
+            cache.persist().await.unwrap();
+
+            assert!(nested_path.parent().unwrap().exists());
+        }
+
+        #[tokio::test]
+        async fn test_persist_creates_nested_cache_file() {
+            let temp_dir = tempdir().unwrap();
+            let nested_path = temp_dir
+                .path()
+                .join("nested")
+                .join("dir")
+                .join("cache.json");
+
+            let cache = FileBasedCache::new(&nested_path).unwrap();
+            let test_file = create_test_file(&temp_dir, "test.txt", "content");
+            cache
+                .update_cache_entry("test-group".to_string(), &test_file)
+                .await
+                .unwrap();
+
+            cache.persist().await.unwrap();
+
+            assert!(nested_path.exists());
+        }
+
+        #[tokio::test]
+        async fn test_persist_invalid_path() {
+            // Try to create cache at root (should fail on most systems)
+            let invalid_path = PathBuf::from("/");
+
+            let cache = FileBasedCache::new(&invalid_path).unwrap();
+            let result = cache.persist().await;
+
+            // Should return an error
+            assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn test_roundtrip_persistence() {
+            let (temp_dir, cache_path) = setup_temp_cache();
+            let test_file1 = create_test_file(&temp_dir, "test1.txt", "content1");
+            let test_file2 = create_test_file(&temp_dir, "test2.txt", "content2");
+
+            // Create first cache and add data
+            {
+                let cache = FileBasedCache::new(&cache_path).unwrap();
+                cache
+                    .update_cache_entry("group1".to_string(), &test_file1)
+                    .await
+                    .unwrap();
+                cache
+                    .update_cache_entry("group2".to_string(), &test_file2)
+                    .await
+                    .unwrap();
+                cache.persist().await.unwrap();
+            }
+
+            // Create new cache from same file
+            let cache2 = FileBasedCache::new(&cache_path).unwrap();
+
+            // Should load previous data
+            let status1 = cache2
+                .check_file("group1".to_string(), &test_file1)
+                .await
+                .unwrap();
+            let status2 = cache2
+                .check_file("group2".to_string(), &test_file2)
+                .await
+                .unwrap();
+
+            assert_eq!(status1, FileCacheStatus::FileMatches);
+            assert_eq!(status2, FileCacheStatus::FileMatches);
+        }
+
+        #[tokio::test]
+        async fn test_concurrent_access() {
+            let (temp_dir, cache_path) = setup_temp_cache();
+            let test_file = create_test_file(&temp_dir, "test.txt", "content");
+
+            let cache = FileBasedCache::new(&cache_path).unwrap();
+
+            // Simulate concurrent access
+            let cache_clone1 = Arc::clone(&cache.data);
+            let cache_clone2 = Arc::clone(&cache.data);
+            let file_path1 = test_file.clone();
+            let file_path2 = test_file.clone();
+
+            let handle1 = tokio::spawn(async move {
+                let checksum = make_checksum(&file_path1).await.unwrap();
+                let mut data = cache_clone1.write().await;
+                data.checksums
+                    .entry("group1".to_string())
+                    .or_default()
+                    .insert(file_path1.display().to_string(), checksum);
+            });
+
+            let handle2 = tokio::spawn(async move {
+                let checksum = make_checksum(&file_path2).await.unwrap();
+                let mut data = cache_clone2.write().await;
+                data.checksums
+                    .entry("group2".to_string())
+                    .or_default()
+                    .insert(file_path2.display().to_string(), checksum);
+            });
+
+            // Wait for both to complete
+            handle1.await.unwrap();
+            handle2.await.unwrap();
+
+            // Both groups should have the file
+            let status1 = cache
+                .check_file("group1".to_string(), &test_file)
+                .await
+                .unwrap();
+            let status2 = cache
+                .check_file("group2".to_string(), &test_file)
+                .await
+                .unwrap();
+
+            assert_eq!(status1, FileCacheStatus::FileMatches);
+            assert_eq!(status2, FileCacheStatus::FileMatches);
+        }
+
+        #[tokio::test]
+        async fn test_make_checksum_normal_file() {
+            let temp_dir = tempdir().unwrap();
+            let file_path = create_test_file(&temp_dir, "test.txt", "test content");
+
+            let checksum = make_checksum(&file_path).await.unwrap();
+
+            assert!(!checksum.is_empty());
+            assert_ne!(checksum, "<not exist>");
+            assert_ne!(checksum, "<dir>");
+        }
+
+        #[tokio::test]
+        async fn test_make_checksum_nonexistent_file() {
+            let temp_dir = tempdir().unwrap();
+            let nonexistent = temp_dir.path().join("nonexistent.txt");
+
+            let checksum = make_checksum(&nonexistent).await.unwrap();
+
+            assert_eq!(checksum, "<not exist>");
+        }
+
+        #[tokio::test]
+        async fn test_make_checksum_directory() {
+            let temp_dir = tempdir().unwrap();
+
+            let checksum = make_checksum(temp_dir.path()).await.unwrap();
+
+            assert_eq!(checksum, "<dir>");
+        }
+
+        #[tokio::test]
+        async fn test_checksum_consistency() {
+            let temp_dir = tempdir().unwrap();
+            let file_path = create_test_file(&temp_dir, "test.txt", "consistent content");
+
+            // Multiple checksum calls should return the same result
+            let checksum1 = make_checksum(&file_path).await.unwrap();
+            let checksum2 = make_checksum(&file_path).await.unwrap();
+
+            assert_eq!(checksum1, checksum2);
+
+            // Different content should produce different checksums
+            fs::write(&file_path, "different content").unwrap();
+            let checksum3 = make_checksum(&file_path).await.unwrap();
+
+            assert_ne!(checksum1, checksum3);
+        }
+    }
+
+    mod noop_cache {
+        use super::*;
+
+        #[tokio::test]
+        async fn test_noop_cache_always_returns_file_changed() {
+            let cache = NoOpCache::default();
+            let temp_path = PathBuf::from("/tmp/test");
+
+            // Should always return FileChanged
+            let status = cache
+                .check_file("test".to_string(), &temp_path)
+                .await
+                .unwrap();
+            assert_eq!(status, FileCacheStatus::FileChanged);
+        }
+
+        #[tokio::test]
+        async fn test_noop_cache_update_and_persist_succeed() {
+            let cache = NoOpCache::default();
+            let temp_path = PathBuf::from("/tmp/test");
+
+            // Should succeed but do nothing
+            cache
+                .update_cache_entry("test".to_string(), &temp_path)
+                .await
+                .unwrap();
+            cache.persist().await.unwrap();
+        }
+
+        #[tokio::test]
+        async fn test_noop_cache_still_returns_file_changed_after_update() {
+            let cache = NoOpCache::default();
+            let temp_path = PathBuf::from("/tmp/test");
+
+            // Update cache entry (should do nothing)
+            cache
+                .update_cache_entry("test".to_string(), &temp_path)
+                .await
+                .unwrap();
+
+            // Still returns FileChanged after update
+            let status = cache
+                .check_file("test".to_string(), &temp_path)
+                .await
+                .unwrap();
+            assert_eq!(status, FileCacheStatus::FileChanged);
+        }
+    }
 }


### PR DESCRIPTION
#208 fixed one caching bug by changing when we update the cache.  
I'm unsure if that PR introduced this bug (it may have) but this PR fixes another.

When ever the _same_ file path is used to cache on in subsequent actions, the cache is updated when the first succeeds, so the cache is read as valid for the second action when it should be invalid.

Example config file

```yaml
apiVersion: scope.github.com/v1alpha
kind: ScopeDoctorGroup
metadata:
  name: ssh
  description: Setup SSH keys for GitHub authentication
spec:
  include: when-required
  needs: []
  actions:
    - name: private-key-exists
      description: Ensures SSH private key exists
      check:
        paths:
          - ~/.ssh/id_ed25519
        commands:
          - ./bin/ssh.sh check private-key
      fix:
        commands:
          - ./bin/ssh.sh fix private-key
    - name: public-key-exists
      description: Ensures SSH public key exists
      check:
        paths:
          - ~/.ssh/id_ed25519.pub
        commands:
          - ./bin/ssh.sh check public-key
      fix:
        commands:
          - ./bin/ssh.sh fix public-key
    - name: key-added
      description: Uploads the pub key to GitHub
      check:
        # The paths in this were previously erroneously cached too early
        # so the check was always passing
        paths:
          # if either of these files have changed, we need to re-check
          - ~/.ssh/id_ed25519
          - ~/.ssh/id_ed25519.pub
        commands:
          - ./bin/ssh.sh check github
      fix:
        commands:
          - ./bin/ssh.sh fix github
```


This because we were keying _only_ off the group name and the fully qualified file name.

This PR updates the cache to _also_ key off of the action name, so that each check has a unique key in the cache.

Old cache format

```json
{
  "checksums": {
    "rails-group": {
      "/path/to/file1.txt": "abc123",
      "/path/to/file2.txt": "def456"
    },
    "ruby-group": {
      "/path/to/ruby-version": "xyz789"
    }
  }
}
```

New cache format

```json
{
  "checksums": {
    "rails-group": {
        "action-1": { "/path/to/file1.txt": "abc123" },
        "action-2": { "/path/to/file2.txt": "def456" }
    },
    "ruby-group": {
      "action-3": { "/path/to/ruby-version": "xyz789" }
    }
  }
}
```

_IMPORTANT:_ This will invalidate any existing cache on a user's machine. The first time a user runs with this new version, we will invalidate all of their existing caches.