### PR TITLE
Add ability to skip groups

### DIFF
--- a/scope/schema/merged.json
+++ b/scope/schema/merged.json
@@ -197,6 +197,11 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "skip": {
+          "description": "Defines conditions under which the group should be skipped. `skip` can be a boolean, in which case the group will be skipped if `true`. Alternatively, it can be a command that will be run to determine if the group should be skipped. If the command returns a zero exit code, the group will be skipped. If the command returns a non-zero exit code, the group will not be skipped.",
+          "default": false,
+          "$ref": "#/definitions/SkipSpec"
         }
       },
       "additionalProperties": false
@@ -476,6 +481,24 @@
         }
       },
       "additionalProperties": false
+    },
+    "SkipSpec": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "required": [
+            "command"
+          ],
+          "properties": {
+            "command": {
+              "type": "string"
+            }
+          }
+        }
+      ]
     },
     "V1AlphaApiVersion": {
       "description": "Version of the Scope API",

--- a/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -213,6 +213,11 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "skip": {
+          "description": "Defines conditions under which the group should be skipped. `skip` can be a boolean, in which case the group will be skipped if `true`. Alternatively, it can be a command that will be run to determine if the group should be skipped. If the command returns a zero exit code, the group will be skipped. If the command returns a non-zero exit code, the group will not be skipped.",
+          "default": false,
+          "$ref": "#/definitions/SkipSpec"
         }
       },
       "additionalProperties": false
@@ -492,6 +497,24 @@
         }
       },
       "additionalProperties": false
+    },
+    "SkipSpec": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "required": [
+            "command"
+          ],
+          "properties": {
+            "command": {
+              "type": "string"
+            }
+          }
+        }
+      ]
     },
     "V1AlphaApiVersion": {
       "description": "Version of the Scope API",

--- a/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -213,6 +213,11 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "skip": {
+          "description": "Defines conditions under which the group should be skipped. `skip` can be a boolean, in which case the group will be skipped if `true`. Alternatively, it can be a command that will be run to determine if the group should be skipped. If the command returns a zero exit code, the group will be skipped. If the command returns a non-zero exit code, the group will not be skipped.",
+          "default": false,
+          "$ref": "#/definitions/SkipSpec"
         }
       },
       "additionalProperties": false
@@ -492,6 +497,24 @@
         }
       },
       "additionalProperties": false
+    },
+    "SkipSpec": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "required": [
+            "command"
+          ],
+          "properties": {
+            "command": {
+              "type": "string"
+            }
+          }
+        }
+      ]
     },
     "V1AlphaApiVersion": {
       "description": "Version of the Scope API",

--- a/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/scope/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -213,6 +213,11 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "skip": {
+          "description": "Defines conditions under which the group should be skipped. `skip` can be a boolean, in which case the group will be skipped if `true`. Alternatively, it can be a command that will be run to determine if the group should be skipped. If the command returns a zero exit code, the group will be skipped. If the command returns a non-zero exit code, the group will not be skipped.",
+          "default": false,
+          "$ref": "#/definitions/SkipSpec"
         }
       },
       "additionalProperties": false
@@ -492,6 +497,24 @@
         }
       },
       "additionalProperties": false
+    },
+    "SkipSpec": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "object",
+          "required": [
+            "command"
+          ],
+          "properties": {
+            "command": {
+              "type": "string"
+            }
+          }
+        }
+      ]
     },
     "V1AlphaApiVersion": {
       "description": "Version of the Scope API",

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -171,20 +171,19 @@ fn transform_inputs(found_config: &FoundConfig, args: &DoctorRunArgs) -> RunTran
             action_runs.push(run);
         }
 
-        let container = GroupActionContainer {
-            group_name: group.metadata.name().to_string(),
-            group: group.clone(),
-            actions: action_runs,
-            additional_report_details: group.extra_report_args.clone(),
-            exec_provider: exec_runner.clone(),
-            exec_working_dir: found_config.working_dir.clone(),
-            sys_path: found_config.bin_path.clone(),
-        };
+        let container = GroupActionContainer::new(
+            group.clone(),
+            action_runs,
+             exec_runner.clone(),
+            found_config.working_dir.clone(),
+            found_config.bin_path.clone(),
+        );
 
-        groups.insert(group.metadata.name().to_string(), container);
+        let group_name = container.group_name().to_string();
+        groups.insert(group_name.clone(), container);
 
         if should_group_run {
-            desired_groups.insert(group.metadata.name().to_string());
+            desired_groups.insert(group_name);
         }
     }
 

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -173,6 +173,7 @@ fn transform_inputs(found_config: &FoundConfig, args: &DoctorRunArgs) -> RunTran
 
         let container = GroupActionContainer {
             group_name: group.metadata.name().to_string(),
+            group: group.clone(),
             actions: action_runs,
             additional_report_details: group.extra_report_args.clone(),
             exec_provider: exec_runner.clone(),

--- a/scope/src/doctor/commands/run.rs
+++ b/scope/src/doctor/commands/run.rs
@@ -174,7 +174,7 @@ fn transform_inputs(found_config: &FoundConfig, args: &DoctorRunArgs) -> RunTran
         let container = GroupActionContainer::new(
             group.clone(),
             action_runs,
-             exec_runner.clone(),
+            exec_runner.clone(),
             found_config.working_dir.clone(),
             found_config.bin_path.clone(),
         );

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -3,7 +3,7 @@ use crate::doctor::check::RuntimeError;
 use crate::models::HelpMetadata;
 use crate::prelude::{
     generate_env_vars, progress_bar_without_pos, ActionReport, ActionTaskReport, CaptureOpts,
-    ExecutionProvider, GroupReport, OutputDestination,
+    ExecutionProvider, GroupReport, OutputDestination, SkipSpec,
 };
 use crate::report_stdout;
 use crate::shared::prelude::DoctorGroup;
@@ -146,8 +146,6 @@ where
     }
 
     pub async fn should_skip_group(&self) -> Result<bool, RuntimeError> {
-        use crate::prelude::SkipSpec;
-
         match &self.group.skip {
             SkipSpec::Skip(should_skip) => Ok(*should_skip),
             SkipSpec::Command { command } => {
@@ -519,7 +517,7 @@ mod tests {
     };
     use crate::doctor::runner::{compute_group_order, GroupActionContainer, RunGroups};
     use crate::doctor::tests::{group_noop, make_root_model_additional};
-    use crate::prelude::{ActionReport, ActionTaskReport, MockExecutionProvider, SkipSpec};
+    use crate::prelude::{ActionReport, ActionTaskReport, MockExecutionProvider};
     use anyhow::Result;
     use std::collections::{BTreeMap, BTreeSet};
     use std::sync::Arc;

--- a/scope/src/models/v1alpha/doctor_group.rs
+++ b/scope/src/models/v1alpha/doctor_group.rs
@@ -115,11 +115,32 @@ pub struct DoctorGroupSpec {
     #[serde(default)]
     pub include: DoctorInclude,
 
+    /// Defines conditions under which the group should be skipped.
+    /// `skip` can be a boolean, in which case the group will be skipped if `true`.
+    /// Alternatively, it can be a command that will be run to determine if the group should
+    /// be skipped. If the command returns a zero exit code, the group will be skipped.
+    /// If the command returns a non-zero exit code, the group will not be skipped.
+    #[serde(default)]
+    pub skip: SkipSpec,
+
     /// defines additional data that needs to be pulled from the system when reporting a bug.
     /// `reportExtraDetails` is a map of `string:string`, the value is a command that should be run.
     /// When a report is built, the commands will be run and automatically included in the report.
     #[serde(default)]
     pub report_extra_details: BTreeMap<String, String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+#[serde(untagged)]
+pub enum SkipSpec {
+    Skip(bool),
+    Command { command: String },
+}
+
+impl Default for SkipSpec {
+    fn default() -> Self {
+        SkipSpec::Skip(false)
+    }
 }
 
 /// Configure how a groups will be used when determining the task graph.

--- a/scope/src/shared/models/internal/doctor_group.rs
+++ b/scope/src/shared/models/internal/doctor_group.rs
@@ -6,7 +6,7 @@ use derive_builder::Builder;
 
 use crate::models::prelude::{ModelMetadata, V1AlphaDoctorGroup};
 use crate::models::HelpMetadata;
-use crate::prelude::{DoctorGroupActionSpec, DoctorInclude};
+use crate::prelude::{DoctorGroupActionSpec, DoctorInclude, SkipSpec};
 use crate::shared::models::internal::{DoctorCommands, DoctorFix};
 
 use super::substitute_templates;
@@ -56,6 +56,8 @@ pub struct DoctorGroup {
     pub run_by_default: bool,
     pub actions: Vec<DoctorGroupAction>,
     pub extra_report_args: BTreeMap<String, String>,
+    #[builder(default)]
+    pub skip: SkipSpec,
 }
 
 impl HelpMetadata for DoctorGroup {
@@ -84,6 +86,7 @@ impl TryFrom<V1AlphaDoctorGroup> for DoctorGroup {
             requires: model.spec.needs,
             run_by_default: model.spec.include == DoctorInclude::ByDefault,
             extra_report_args: model.spec.report_extra_details,
+            skip: model.spec.skip,
         })
     }
 }

--- a/scope/tests/scope_doctor.rs
+++ b/scope/tests/scope_doctor.rs
@@ -247,3 +247,26 @@ fn test_group_skip_command_fail() {
 
     test_helper.clean_work_dir();
 }
+
+#[test]
+fn test_group_skip_subsequent_groups_run() {
+    let test_helper = ScopeTestHelper::new(
+        "test_group_skip_subsequent_groups_run",
+        "group-skip-allows-later-groups-to-run",
+    );
+    let result = test_helper.doctor_run(None);
+
+    result
+        .success()
+        .stdout(predicate::str::contains(
+            "Group skipped, group: \"group-skipped\"",
+        ))
+        .stdout(predicate::str::contains(
+            "Check was successful, group: \"group-runs\", name: \"should-run\"",
+        ))
+        .stdout(predicate::str::contains(
+            "Summary: 2 groups succeeded, 1 groups skipped",
+        ));
+
+    test_helper.clean_work_dir();
+}

--- a/scope/tests/scope_doctor.rs
+++ b/scope/tests/scope_doctor.rs
@@ -159,3 +159,91 @@ fn test_sub_command_works() {
     ));
     test_helper.clean_work_dir();
 }
+
+#[test]
+fn test_group_skip_boolean_true() {
+    let test_helper = ScopeTestHelper::new("test_group_skip_boolean_true", "group-skip-boolean");
+    let result = test_helper.doctor_run(None);
+
+    result
+        .success()
+        .stdout(predicate::str::contains(
+            "Group skipped, group: \"group-skip-boolean\"",
+        ))
+        .stdout(predicate::str::contains("This check should not run").not())
+        .stdout(predicate::str::contains("This fix should not run").not())
+        .stdout(predicate::str::contains(
+            "Summary: 0 groups succeeded, 1 groups skipped",
+        ));
+
+    test_helper.clean_work_dir();
+}
+
+#[test]
+fn test_group_skip_boolean_false() {
+    let test_helper =
+        ScopeTestHelper::new("test_group_skip_boolean_false", "group-skip-boolean-false");
+    let result = test_helper.doctor_run(None);
+
+    result
+        .success()
+        .stdout(predicate::str::contains("Group skipped").not())
+        .stdout(predicate::str::contains(
+            "Check was successful, group: \"group-skip-boolean-false\", name: \"should-run\"",
+        ))
+        .stdout(predicate::str::contains("Summary: 1 groups succeeded"));
+
+    test_helper.clean_work_dir();
+}
+
+#[test]
+fn test_group_skip_default() {
+    let test_helper = ScopeTestHelper::new("test_group_skip_default", "group-skip-default");
+    let result = test_helper.doctor_run(None);
+
+    result
+        .success()
+        .stdout(predicate::str::contains("Group skipped").not())
+        .stdout(predicate::str::contains(
+            "Check was successful, group: \"group-skip-default\", name: \"should-run\"",
+        ))
+        .stdout(predicate::str::contains("Summary: 1 groups succeeded"));
+
+    test_helper.clean_work_dir();
+}
+
+#[test]
+fn test_group_skip_command_success() {
+    let test_helper = ScopeTestHelper::new("test_group_skip_command_success", "group-skip-command");
+    let result = test_helper.doctor_run(None);
+
+    result
+        .success()
+        .stdout(predicate::str::contains(
+            "Group skipped, group: \"group-skip-command\"",
+        ))
+        .stdout(predicate::str::contains("This check should not run").not())
+        .stdout(predicate::str::contains("This fix should not run").not())
+        .stdout(predicate::str::contains(
+            "Summary: 0 groups succeeded, 1 groups skipped",
+        ));
+
+    test_helper.clean_work_dir();
+}
+
+#[test]
+fn test_group_skip_command_fail() {
+    let test_helper =
+        ScopeTestHelper::new("test_group_skip_command_fail", "group-skip-command-fail");
+    let result = test_helper.doctor_run(None);
+
+    result
+        .success()
+        .stdout(predicate::str::contains("Group skipped").not())
+        .stdout(predicate::str::contains(
+            "Check was successful, group: \"group-skip-command-fail\", name: \"should-run\"",
+        ))
+        .stdout(predicate::str::contains("Summary: 1 groups succeeded"));
+
+    test_helper.clean_work_dir();
+}

--- a/scope/tests/test-cases/group-skip-allows-later-groups-to-run/.scope/app.yaml
+++ b/scope/tests/test-cases/group-skip-allows-later-groups-to-run/.scope/app.yaml
@@ -1,0 +1,10 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: app
+  description: Imports a group that is skipped and another that should run 
+spec:
+  needs: 
+    - group-skipped
+    - group-runs
+  actions: []

--- a/scope/tests/test-cases/group-skip-allows-later-groups-to-run/.scope/group-runs.yaml
+++ b/scope/tests/test-cases/group-skip-allows-later-groups-to-run/.scope/group-runs.yaml
@@ -1,0 +1,15 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: group-runs
+  description: This group should be run even if a previous group is skipped
+spec:
+  include: when-required
+  actions:
+    - name: should-run
+      check:
+        commands:
+          - echo "This check should run"
+      fix:
+        commands:
+          - echo "This fix should run"

--- a/scope/tests/test-cases/group-skip-allows-later-groups-to-run/.scope/group-skipped.yaml
+++ b/scope/tests/test-cases/group-skip-allows-later-groups-to-run/.scope/group-skipped.yaml
@@ -1,0 +1,16 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: group-skipped
+  description: Test group with skip boolean set to true
+spec:
+  include: when-required
+  skip: true
+  actions:
+    - name: should-not-run
+      check:
+        commands:
+          - echo "This check should not run"
+      fix:
+        commands:
+          - echo "This fix should not run"

--- a/scope/tests/test-cases/group-skip-boolean-false/.scope/group.yaml
+++ b/scope/tests/test-cases/group-skip-boolean-false/.scope/group.yaml
@@ -1,0 +1,15 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: group-skip-boolean-false
+  description: Test group with skip boolean set to false
+spec:
+  skip: false
+  actions:
+    - name: should-run
+      check:
+        commands:
+          - echo "This check should run"
+      fix:
+        commands:
+          - echo "This fix should run"

--- a/scope/tests/test-cases/group-skip-boolean/.scope/group.yaml
+++ b/scope/tests/test-cases/group-skip-boolean/.scope/group.yaml
@@ -1,0 +1,15 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: group-skip-boolean
+  description: Test group with skip boolean set to true
+spec:
+  skip: true
+  actions:
+    - name: should-not-run
+      check:
+        commands:
+          - echo "This check should not run"
+      fix:
+        commands:
+          - echo "This fix should not run"

--- a/scope/tests/test-cases/group-skip-command-fail/.scope/group.yaml
+++ b/scope/tests/test-cases/group-skip-command-fail/.scope/group.yaml
@@ -1,0 +1,16 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: group-skip-command-fail
+  description: Test group with skip command that returns failure
+spec:
+  skip: 
+    command: "false"
+  actions:
+    - name: should-run
+      check:
+        commands:
+          - echo "This check should run"
+      fix:
+        commands:
+          - echo "This fix should run"

--- a/scope/tests/test-cases/group-skip-command/.scope/group.yaml
+++ b/scope/tests/test-cases/group-skip-command/.scope/group.yaml
@@ -1,0 +1,16 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: group-skip-command
+  description: Test group with skip command that returns success
+spec:
+  skip: 
+    command: "true"
+  actions:
+    - name: should-not-run
+      check:
+        commands:
+          - echo "This check should not run"
+      fix:
+        commands:
+          - echo "This fix should not run"

--- a/scope/tests/test-cases/group-skip-default/.scope/group.yaml
+++ b/scope/tests/test-cases/group-skip-default/.scope/group.yaml
@@ -1,0 +1,14 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: group-skip-default
+  description: Test group with skip field omitted (defaults to false)
+spec:
+  actions:
+    - name: should-run
+      check:
+        commands:
+          - echo "This check should run"
+      fix:
+        commands:
+          - echo "This fix should run"


### PR DESCRIPTION
We've found it desirable to be able to skip entire groups, if certain conditions are met.  
Previously, we did this by ensuring all checks in all actions in a group always exited with success, which works, but is inconvenient, a little error prone, and does (minimally) increase execution time because we still have to execute all the checks for all the actions. It's also unclear to the user that we are skipping those groups.

This PR adds the ability to bypass a group _either_ by setting `spec.skip: true` _or_ by adding a `spec.skip.command`.  
When the `command` returns `0` (success), the group is skipped.  
When it fails (returns non-0), the group is executed.  

When `spec.skip` is omitted, we default to `false`, which makes this a backward compatible change.

Examples
---

### Skip Omitted

Omitting the new field is equivalent to `spec.skip: false` and will behave the same as it does today (i.e. the group is run).

```yaml
apiVersion: scope.github.com/v1alpha
kind: ScopeDoctorGroup
metadata:
  name: group-skip-default
  description: Test group with skip field omitted (defaults to false)
spec:
  actions:
    - name: should-run
      check:
        commands:
          - echo "This check should run"
      fix:
        commands:
          - echo "This fix should run"
```

### Skip False

When `skip: false`, the behavior is the same as it is today (i.e. the group is run).

```yaml
apiVersion: scope.github.com/v1alpha
kind: ScopeDoctorGroup
metadata:
  name: group-skip-boolean-false
  description: Test group with skip boolean set to false
spec:
  skip: false
  actions:
    - name: should-run
      check:
        commands:
          - echo "This check should run"
      fix:
        commands:
          - echo "This fix should run"
```

### Skip True

When `skip: true`, the group will NOT be executed.   
This can be useful for temporarily disabling a group that is included by other groups or for putting a group into the correct place in the dependency tree prior to enabling it.

```yaml
apiVersion: scope.github.com/v1alpha
kind: ScopeDoctorGroup
metadata:
  name: group-skip-boolean
  description: Test group with skip boolean set to true
spec:
  skip: true
  actions:
    - name: should-not-run
      check:
        commands:
          - echo "This check should not run"
      fix:
        commands:
          - echo "This fix should not run"
```

### Skip Command

This is useful for creating feature flags _OR_ allowing users to opt out of groups.  
When the `command` returns `0`, the entire group is skipped, otherwise the group is run.

Below is an example of using an environment variable to conditionally skip the group.

```yaml
apiVersion: scope.github.com/v1alpha
kind: ScopeDoctorGroup
metadata:
  name: group-skip-command
  description: Test group with skip command that returns success
spec:
  skip: 
    command: bash -c '[ -n "$APPLESAUCE" ] && [ "$APPLESAUCE" = "1" ]'
  actions:
    - name: should-not-run
      check:
        commands:
          - echo "This check should not run"
      fix:
        commands:
          - echo "This fix should not run"
```